### PR TITLE
feat: add mic selection

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -181,6 +181,7 @@ export default class AnamClient {
           inputAudio: {
             inputAudioState: this.inputAudioState,
             userProvidedMediaStream: userProvidedAudioStream,
+            audioDeviceId: this.clientOptions?.audioDeviceId,
           },
         },
         this.publicEventEmitter,

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -37,6 +37,7 @@ export class StreamingClient {
   private audioElement: HTMLAudioElement | null = null;
   private audioStream: MediaStream | null = null;
   private inputAudioState: InputAudioState = { isMuted: false };
+  private audioDeviceId: string | undefined;
 
   constructor(
     sessionId: string,
@@ -75,6 +76,7 @@ export class StreamingClient {
       options.engine.baseUrl,
       sessionId,
     );
+    this.audioDeviceId = options.inputAudio.audioDeviceId;
   }
 
   private onInputAudioStateChange(
@@ -420,10 +422,19 @@ export class StreamingClient {
         );
       }
     } else {
+      const audioConstraints: MediaTrackConstraints = {
+        echoCancellation: true,
+      };
+
+      // If an audio device ID is provided in the options, use it
+      if (this.audioDeviceId) {
+        audioConstraints.deviceId = {
+          exact: this.audioDeviceId,
+        };
+      }
+
       this.inputAudioStream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-        },
+        audio: audioConstraints,
       });
     }
 

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -4,4 +4,5 @@ import { VoiceDetectionOptions } from './VoiceDetectionOptions';
 export interface AnamPublicClientOptions {
   api?: CoreApiRestClientOptions;
   voiceDetection?: VoiceDetectionOptions;
+  audioDeviceId?: string;
 }

--- a/src/types/streaming/InputAudioOptions.ts
+++ b/src/types/streaming/InputAudioOptions.ts
@@ -3,4 +3,5 @@ import { InputAudioState } from '../InputAudioState';
 export interface InputAudioOptions {
   inputAudioState: InputAudioState;
   userProvidedMediaStream?: MediaStream;
+  audioDeviceId?: string;
 }


### PR DESCRIPTION
Adds a new option to specify the browser audio device ID
This allows us to create a mic selection tool on the frontend of consuming apps