### PR TITLE
feat(js-sdk): add proxy transport and custom signaling

### DIFF
--- a/src/modules/ExternalSessionClient.ts
+++ b/src/modules/ExternalSessionClient.ts
@@ -1,0 +1,50 @@
+import { StartSessionOptions } from '../types/coreApi/StartSessionOptions';
+
+export interface ExternalSessionClientConfig {
+  baseUrl: string; // e.g., window.location.origin
+  startSessionPath?: string; // default: '/v1/auth/session'
+  getUserId: () => string;
+  headers?: Record<string, string>;
+}
+
+export interface ExternalStartSessionResponse {
+  sessionId: string;
+  engineHost: string;
+  engineProtocol: 'http' | 'https';
+  signallingEndpoint: string;
+  clientConfig?: {
+    heartbeatIntervalSeconds?: number;
+    maxWsReconnectionAttempts?: number;
+    iceServers: RTCIceServer[];
+  };
+  userId?: string;
+}
+
+export class ExternalSessionClient {
+  private config: ExternalSessionClientConfig;
+
+  constructor(config: ExternalSessionClientConfig) {
+    this.config = config;
+  }
+
+  public async startSession(
+    _sessionOptions?: StartSessionOptions,
+  ): Promise<ExternalStartSessionResponse> {
+    const path = this.config.startSessionPath ?? '/v1/auth/session';
+    const userId = this.config.getUserId();
+    const res = await fetch(this.config.baseUrl + path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.config.headers,
+      },
+      body: JSON.stringify({ userId }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`External session start failed: ${res.status} ${text}`);
+    }
+    const data = (await res.json()) as ExternalStartSessionResponse;
+    return data;
+  }
+}

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -5,6 +5,16 @@ export interface AnamPublicClientOptions {
   voiceDetection?: VoiceDetectionOptions;
   audioDeviceId?: string;
   disableInputAudio?: boolean;
+  transport?: {
+    mode?: 'direct' | 'proxy';
+    proxy?: {
+      baseUrl: string; // e.g., window.location.origin
+      startSessionPath?: string; // default '/v1/auth/session'
+      agentWsPathTemplate?: string; // e.g., '/v1/agents/{userId}/ws'
+      getUserId: () => string;
+      headers?: Record<string, string>;
+    };
+  };
   metrics?: {
     showPeerConnectionStatsReport?: boolean;
     peerConnectionStatsReportOutputFormat?: 'console' | 'json';

--- a/src/types/shims-buffer.d.ts
+++ b/src/types/shims-buffer.d.ts
@@ -1,0 +1,4 @@
+declare module 'buffer' {
+  // Minimal shim to satisfy TS in browser environments
+  export const Buffer: any;
+}

--- a/src/types/signalling/SignalMessage.ts
+++ b/src/types/signalling/SignalMessage.ts
@@ -11,7 +11,8 @@ export enum SignalMessageAction {
 }
 
 export interface SignalMessage {
-  actionType: SignalMessageAction;
+  // Allow custom action types beyond the enum
+  actionType: string;
   sessionId: string;
   payload: object | string;
 }

--- a/src/types/signalling/SignallingClientOptions.ts
+++ b/src/types/signalling/SignallingClientOptions.ts
@@ -1,8 +1,13 @@
 export interface SignallingURLOptions {
-  baseUrl: string;
+  baseUrl?: string;
   protocol?: string;
   port?: string;
   signallingPath?: string;
+  /**
+   * When provided, a complete absolute WebSocket URL is used as-is.
+   * Example: wss://example.com/v1/agents/123/ws?engineHost=...&engineProtocol=...&signallingEndpoint=...&session_id=...
+   */
+  absoluteWsUrl?: string;
 }
 
 export interface SignallingClientOptions {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "strict": true,
     "stripInternal": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"],
+    "types": []
   },
   "include": ["src"],
   "exclude": ["node_modules/**/*.ts"]


### PR DESCRIPTION
This allows a user to choose to use a proxy of the Websocket client 
e.g. with https://github.com/stukennedy/anam-ws-proxy

Use-case for this is a man-in-the-middle approach, where a 3rd-party server handles their own orchestration layer -> LLM inference and then stream talks directly in the Anam Websocket, cutting out the need to send responses back to the client and for the client to send the talk stream to Anam.
The client also doesn't need to negotiate the session at all, just gets a signalling websocket from the server which negotiates the WebRTC session.
