### PR TITLE
feat: convert client tool call events to public type

### DIFF
--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -8,6 +8,7 @@ import {
   InternalEventEmitter,
   PublicEventEmitter,
   SignallingClient,
+  ToolCallManager,
 } from '../modules';
 import {
   AnamEvent,
@@ -21,6 +22,7 @@ import {
   SignalMessage,
   SignalMessageAction,
   StreamingClientOptions,
+  WebRtcClientToolEvent,
   WebRtcTextMessageEvent,
 } from '../types';
 import { TalkMessageStream } from '../types/TalkMessageStream';
@@ -673,13 +675,19 @@ export class StreamingClient {
             );
             break;
           case DataChannelMessage.CLIENT_TOOL_EVENT:
+            const webRtcToolEvent = message.data as WebRtcClientToolEvent;
+
             this.internalEventEmitter.emit(
               InternalEvent.WEBRTC_CLIENT_TOOL_EVENT_RECEIVED,
-              message.data as ClientToolEvent,
+              webRtcToolEvent,
             );
+            const clientToolEvent =
+              ToolCallManager.WebRTCClientToolEventToClientToolEvent(
+                webRtcToolEvent,
+              );
             this.publicEventEmitter.emit(
               AnamEvent.CLIENT_TOOL_EVENT_RECEIVED,
-              message.data as ClientToolEvent,
+              clientToolEvent,
             );
             break;
           // Unknown message types are silently ignored to maintain forward compatibility

--- a/src/modules/ToolCallManager.ts
+++ b/src/modules/ToolCallManager.ts
@@ -1,0 +1,20 @@
+import { ClientToolEvent, WebRtcClientToolEvent } from '../types/streaming';
+
+export class ToolCallManager {
+  /**
+   * Converts a WebRtcClientToolEvent to a ClientToolEvent
+   */
+  static WebRTCClientToolEventToClientToolEvent(
+    webRtcEvent: WebRtcClientToolEvent,
+  ): ClientToolEvent {
+    return {
+      eventUid: webRtcEvent.event_uid,
+      sessionId: webRtcEvent.session_id,
+      eventName: webRtcEvent.event_name,
+      eventData: webRtcEvent.event_data,
+      timestamp: webRtcEvent.timestamp,
+      timestampUserAction: webRtcEvent.timestamp_user_action,
+      userActionCorrelationId: webRtcEvent.user_action_correlation_id,
+    };
+  }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -5,3 +5,4 @@ export { InternalEventEmitter } from './InternalEventEmitter';
 export { MessageHistoryClient } from './MessageHistoryClient';
 export { PublicEventEmitter } from './PublicEventEmitter';
 export { StreamingClient } from './StreamingClient';
+export { ToolCallManager } from './ToolCallManager';

--- a/src/types/events/internal/InternalEventCallbacks.ts
+++ b/src/types/events/internal/InternalEventCallbacks.ts
@@ -2,7 +2,7 @@ import {
   InternalEvent,
   SignalMessage,
   WebRtcTextMessageEvent,
-  ClientToolEvent,
+  WebRtcClientToolEvent,
 } from '../../index';
 
 export type InternalEventCallbacks = {
@@ -14,6 +14,6 @@ export type InternalEventCallbacks = {
     message: WebRtcTextMessageEvent,
   ) => void;
   [InternalEvent.WEBRTC_CLIENT_TOOL_EVENT_RECEIVED]: (
-    clientToolEvent: ClientToolEvent,
+    webRtcToolEvent: WebRtcClientToolEvent,
   ) => void;
 };

--- a/src/types/streaming/ClientToolEvent.ts
+++ b/src/types/streaming/ClientToolEvent.ts
@@ -1,15 +1,12 @@
 export interface ClientToolEvent {
   // Core event fields
-  event_uid: string; // Unique ID for this event
-  session_id: string; // Session ID
-  event_name: string; // The tool name (e.g., "redirect")
-  event_data: Record<string, any>; // LLM-generated parameters
+  eventUid: string; // Unique ID for this event
+  sessionId: string; // Session ID
+  eventName: string; // The tool name (e.g., "redirect")
+  eventData: Record<string, any>; // LLM-generated parameters
 
   // Timing & correlation
   timestamp: string; // ISO timestamp when event was created
-  timestamp_user_action: string; // ISO timestamp of user action that triggered this
-  user_action_correlation_id: string; // Correlation ID for tracking
-
-  // Metadata
-  used_outside_engine: boolean; // Always true for client events
+  timestampUserAction: string; // ISO timestamp of user action that triggered this
+  userActionCorrelationId: string; // Correlation ID for tracking
 }

--- a/src/types/streaming/WebRtcClientToolEvent.ts
+++ b/src/types/streaming/WebRtcClientToolEvent.ts
@@ -1,0 +1,15 @@
+export interface WebRtcClientToolEvent {
+  // Core event fields
+  event_uid: string; // Unique ID for this event
+  session_id: string; // Session ID
+  event_name: string; // The tool name (e.g., "redirect")
+  event_data: Record<string, any>; // LLM-generated parameters
+
+  // Timing & correlation
+  timestamp: string; // ISO timestamp when event was created
+  timestamp_user_action: string; // ISO timestamp of user action that triggered this
+  user_action_correlation_id: string; // Correlation ID for tracking
+
+  // Metadata
+  used_outside_engine: boolean; // Always true for client events
+}

--- a/src/types/streaming/index.ts
+++ b/src/types/streaming/index.ts
@@ -1,5 +1,6 @@
 export type { WebRtcTextMessageEvent } from './WebRtcTextMessageEvent';
 export type { ClientToolEvent } from './ClientToolEvent';
+export type { WebRtcClientToolEvent } from './WebRtcClientToolEvent';
 export type { StreamingClientOptions } from './StreamingClientOptions';
 export type { InputAudioOptions } from './InputAudioOptions';
 export { DataChannelMessage } from './DataChannelMessage';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Convert WebRTC client tool call events to a camelCase public ClientToolEvent, ensuring a consistent API shape for consumers. StreamingClient now converts and emits the public event while keeping the internal WebRTC event for internal listeners.

- **Refactors**
  - Added ToolCallManager to convert WebRtcClientToolEvent -> ClientToolEvent.
  - StreamingClient emits InternalEvent.WEBRTC_CLIENT_TOOL_EVENT_RECEIVED with WebRtcClientToolEvent, then emits AnamEvent.CLIENT_TOOL_EVENT_RECEIVED with ClientToolEvent.
  - ClientToolEvent fields changed to camelCase; removed used_outside_engine.
  - Updated InternalEventCallbacks to use WebRtcClientToolEvent for the internal event.

- **Migration**
  - Update consumers to use camelCase fields: eventUid, sessionId, eventName, eventData, timestamp, timestampUserAction, userActionCorrelationId.
  - used_outside_engine is no longer present on the public ClientToolEvent.

<sup>Written for commit f3cc5a2e608289b553493d036885e78b9881f53b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

