### PR TITLE
feat: add server side heartbeat signal message case

### DIFF
--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -502,8 +502,10 @@ export class StreamingClient {
         const sessionId = signalMessage.sessionId as string;
         this.publicEventEmitter.emit(AnamEvent.SESSION_READY, sessionId);
         break;
+      case SignalMessageAction.HEARTBEAT:
+        break;
       default:
-        console.error(
+        console.warn(
           'StreamingClient - onSignalMessage: unknown signal message action type. Is your anam-sdk version up to date?',
           signalMessage,
         );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
StreamingClient now handles server-side HEARTBEAT signals as a no-op to avoid false errors. Unknown signal actions now log a warning instead of an error to reduce noise.

<sup>Written for commit ee1ac4ca901ade2ced25f0320778d6932699eb8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

