### PR TITLE
fix: client metrics proxy

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_ANAM_API_VERSION,
   DEFAULT_ANAM_METRICS_BASE_URL,
   sendClientMetric,
+  setClientMetricsApiGateway,
   setClientMetricsBaseUrl,
   setMetricsContext,
 } from './lib/ClientMetrics';
@@ -76,6 +77,11 @@ export default class AnamClient {
         options.api.baseUrl || DEFAULT_ANAM_METRICS_BASE_URL,
         options.api.apiVersion || DEFAULT_ANAM_API_VERSION,
       );
+    }
+
+    // Pass API Gateway config to metrics module so metrics are routed through the gateway
+    if (options?.api?.apiGateway?.enabled) {
+      setClientMetricsApiGateway(options.api.apiGateway);
     }
 
     this.publicEventEmitter = new PublicEventEmitter();

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -7,6 +7,7 @@ import {
   sendClientMetric,
   setClientMetricsApiGateway,
   setClientMetricsBaseUrl,
+  setClientMetricsDisabled,
   setMetricsContext,
 } from './lib/ClientMetrics';
 import { generateCorrelationId } from './lib/correlationId';
@@ -82,6 +83,11 @@ export default class AnamClient {
     // Pass API Gateway config to metrics module so metrics are routed through the gateway
     if (options?.api?.apiGateway?.enabled) {
       setClientMetricsApiGateway(options.api.apiGateway);
+    }
+
+    // Allow disabling client metrics telemetry
+    if (options?.metrics?.disableClientMetrics) {
+      setClientMetricsDisabled(true);
     }
 
     this.publicEventEmitter = new PublicEventEmitter();

--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -15,6 +15,7 @@ export enum ClientMetricMeasurement {
 let anamCurrentBaseUrl = DEFAULT_ANAM_METRICS_BASE_URL;
 let anamCurrentApiVersion = DEFAULT_ANAM_API_VERSION;
 let apiGatewayConfig: ApiGatewayConfig | undefined;
+let metricsDisabled = false;
 
 export const setClientMetricsBaseUrl = (
   baseUrl: string,
@@ -28,6 +29,10 @@ export const setClientMetricsApiGateway = (
   config: ApiGatewayConfig | undefined,
 ) => {
   apiGatewayConfig = config;
+};
+
+export const setClientMetricsDisabled = (disabled: boolean) => {
+  metricsDisabled = disabled;
 };
 
 export interface AnamMetricsContext {
@@ -51,6 +56,11 @@ export const sendClientMetric = async (
   value: string,
   tags?: Record<string, string | number>,
 ) => {
+  // Skip sending metrics if disabled
+  if (metricsDisabled) {
+    return;
+  }
+
   try {
     const metricTags: Record<string, string | number> = {
       ...CLIENT_METADATA,

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -9,6 +9,12 @@ export interface AnamPublicClientOptions {
   metrics?: {
     showPeerConnectionStatsReport?: boolean;
     peerConnectionStatsReportOutputFormat?: 'console' | 'json';
+    /**
+     * When true, disables sending client metrics to Anam's telemetry endpoint.
+     * Useful for privacy-conscious deployments or air-gapped environments.
+     * @default false
+     */
+    disableClientMetrics?: boolean;
   };
   iceServers?: RTCIceServer[];
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes client metrics proxying by routing through the configured API Gateway when enabled. Adds an option to disable client metrics telemetry.

- **Bug Fixes**
  - Passes API Gateway config from AnamClient to the metrics module.
  - Routes metrics through the gateway when enabled and sets X-Anam-Target-Url; falls back to direct Anam API otherwise.

- **New Features**
  - Adds metrics.disableClientMetrics to stop sending telemetry.

<sup>Written for commit 5ba86700ee50807aa028ea38efa9f09e19acafc7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

