### PR TITLE
feat: agent audio input stream

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -616,29 +616,6 @@ export default class AnamClient {
     return this.streamingClient.startTalkMessageStream(correlationId);
   }
 
-  /**
-   * Create agent audio input stream for sending external audio to engine.
-   * Call once after session starts. Stream persists for session lifetime.
-   *
-   * @param config - Audio format configuration (encoding, sampleRate, channels)
-   * @returns AgentAudioInputStream instance for sending audio chunks
-   * @throws Error if session is not started
-   *
-   * @example
-   * ```typescript
-   * const stream = client.createAgentAudioInputStream({
-   *   encoding: 'pcm_s16le',
-   *   sampleRate: 24000,
-   *   channels: 1,
-   * });
-   *
-   * // Send audio as it arrives
-   * stream.sendAudioChunk(pcmAudioData);
-   *
-   * // Signal end of sequence
-   * stream.endSequence();
-   * ```
-   */
   public createAgentAudioInputStream(
     config: AgentAudioInputConfig,
   ): AgentAudioInputStream {

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -22,6 +22,7 @@ import {
 import {
   AnamClientOptions,
   AnamEvent,
+  AgentAudioInputConfig,
   AudioPermissionState,
   ConnectionClosedCode,
   EventCallbacks,
@@ -30,6 +31,7 @@ import {
   StartSessionOptions,
   StartSessionResponse,
 } from './types';
+import { AgentAudioInputStream } from './types/AgentAudioInputStream';
 import { TalkMessageStream } from './types/TalkMessageStream';
 export default class AnamClient {
   private publicEventEmitter: PublicEventEmitter;
@@ -612,6 +614,40 @@ export default class AnamClient {
     }
 
     return this.streamingClient.startTalkMessageStream(correlationId);
+  }
+
+  /**
+   * Create agent audio input stream for sending external audio to engine.
+   * Call once after session starts. Stream persists for session lifetime.
+   *
+   * @param config - Audio format configuration (encoding, sampleRate, channels)
+   * @returns AgentAudioInputStream instance for sending audio chunks
+   * @throws Error if session is not started
+   *
+   * @example
+   * ```typescript
+   * const stream = client.createAgentAudioInputStream({
+   *   encoding: 'pcm_s16le',
+   *   sampleRate: 24000,
+   *   channels: 1,
+   * });
+   *
+   * // Send audio as it arrives
+   * stream.sendAudioChunk(pcmAudioData);
+   *
+   * // Signal end of sequence
+   * stream.endSequence();
+   * ```
+   */
+  public createAgentAudioInputStream(
+    config: AgentAudioInputConfig,
+  ): AgentAudioInputStream {
+    if (!this.streamingClient) {
+      throw new Error(
+        'Failed to create agent audio input stream: session is not started.',
+      );
+    }
+    return this.streamingClient.createAgentAudioInputStream(config);
   }
 
   /**

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -7,6 +7,7 @@ import {
   SignallingClientOptions,
   ConnectionClosedCode,
   ApiGatewayConfig,
+  AgentAudioInputPayload,
 } from '../types';
 import { TalkMessageStreamPayload } from '../types/signalling/TalkMessageStreamPayload';
 
@@ -155,6 +156,24 @@ export class SignallingClient {
       payload: payload,
     };
     this.sendSignalMessage(chatMessage);
+  }
+
+  public sendAgentAudioInput(payload: AgentAudioInputPayload): void {
+    const message: SignalMessage = {
+      actionType: SignalMessageAction.AGENT_AUDIO_INPUT,
+      sessionId: this.sessionId,
+      payload: payload,
+    };
+    this.sendSignalMessage(message);
+  }
+
+  public sendAgentAudioInputEnd(): void {
+    const message: SignalMessage = {
+      actionType: SignalMessageAction.AGENT_AUDIO_INPUT_END,
+      sessionId: this.sessionId,
+      payload: {},
+    };
+    this.sendSignalMessage(message);
   }
 
   private closeSocket() {

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -13,6 +13,7 @@ import {
 import {
   AnamEvent,
   ApiGatewayConfig,
+  AgentAudioInputConfig,
   AudioPermissionState,
   ClientToolEvent,
   ConnectionClosedCode,
@@ -25,6 +26,7 @@ import {
   WebRtcClientToolEvent,
   WebRtcTextMessageEvent,
 } from '../types';
+import { AgentAudioInputStream } from '../types/AgentAudioInputStream';
 import { TalkMessageStream } from '../types/TalkMessageStream';
 import { TalkStreamInterruptedSignalMessage } from '../types/signalling/TalkStreamInterruptedSignalMessage';
 
@@ -58,6 +60,7 @@ export class StreamingClient {
   private showPeerConnectionStatsReport: boolean = false;
   private peerConnectionStatsReportOutputFormat: 'console' | 'json' = 'console';
   private statsCollectionInterval: ReturnType<typeof setInterval> | null = null;
+  private agentAudioInputStream: AgentAudioInputStream | null = null;
 
   constructor(
     sessionId: string,
@@ -409,6 +412,20 @@ export class StreamingClient {
       this.internalEventEmitter,
       this.signallingClient,
     );
+  }
+
+  public createAgentAudioInputStream(
+    config: AgentAudioInputConfig,
+  ): AgentAudioInputStream {
+    this.agentAudioInputStream = new AgentAudioInputStream(
+      config,
+      this.signallingClient,
+    );
+    return this.agentAudioInputStream;
+  }
+
+  public getAgentAudioInputStream(): AgentAudioInputStream | null {
+    return this.agentAudioInputStream;
   }
 
   private async initPeerConnection() {

--- a/src/types/AgentAudioInputStream.ts
+++ b/src/types/AgentAudioInputStream.ts
@@ -62,10 +62,7 @@ export class AgentAudioInputStream {
   private arrayBufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
     const bytes =
       buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.byteLength; i++) {
-      binary += String.fromCharCode(bytes[i]);
-    }
+    const binary = Array.from(bytes, byte => String.fromCharCode(byte)).join('');
     return btoa(binary);
   }
 }

--- a/src/types/AgentAudioInputStream.ts
+++ b/src/types/AgentAudioInputStream.ts
@@ -5,6 +5,7 @@ import { AgentAudioInputPayload } from './signalling/AgentAudioInputPayload';
 export class AgentAudioInputStream {
   private signallingClient: SignallingClient;
   private config: AgentAudioInputConfig;
+  private sequenceNumber: number = 0;
 
   constructor(
     config: AgentAudioInputConfig,
@@ -29,6 +30,7 @@ export class AgentAudioInputStream {
       encoding: this.config.encoding,
       sampleRate: this.config.sampleRate,
       channels: this.config.channels,
+      sequenceNumber: this.sequenceNumber++,
     };
 
     this.signallingClient.sendAgentAudioInput(payload);
@@ -36,10 +38,18 @@ export class AgentAudioInputStream {
 
   /**
    * Signal end of the current audio sequence/turn.
-   * Sends AGENT_AUDIO_INPUT_END signal message.
+   * Sends AGENT_AUDIO_INPUT_END signal message and resets sequence number.
    */
   public endSequence(): void {
     this.signallingClient.sendAgentAudioInputEnd();
+    this.sequenceNumber = 0;
+  }
+
+  /**
+   * Get the current sequence number (number of chunks sent in current sequence).
+   */
+  public getSequenceNumber(): number {
+    return this.sequenceNumber;
   }
 
   /**

--- a/src/types/AgentAudioInputStream.ts
+++ b/src/types/AgentAudioInputStream.ts
@@ -16,10 +16,13 @@ export class AgentAudioInputStream {
 
   /**
    * Send PCM audio chunk to server.
-   * @param audioData - Raw PCM audio bytes
+   * @param audioData - Raw PCM audio bytes (ArrayBuffer/Uint8Array) or base64-encoded string
    */
-  public sendAudioChunk(audioData: ArrayBuffer | Uint8Array): void {
-    const base64 = this.arrayBufferToBase64(audioData);
+  public sendAudioChunk(audioData: ArrayBuffer | Uint8Array | string): void {
+    const base64 =
+      typeof audioData === 'string'
+        ? audioData
+        : this.arrayBufferToBase64(audioData);
 
     const payload: AgentAudioInputPayload = {
       audioData: base64,

--- a/src/types/AgentAudioInputStream.ts
+++ b/src/types/AgentAudioInputStream.ts
@@ -1,0 +1,58 @@
+import { SignallingClient } from '../modules/SignallingClient';
+import { AgentAudioInputConfig } from './signalling/AgentAudioInputConfig';
+import { AgentAudioInputPayload } from './signalling/AgentAudioInputPayload';
+
+export class AgentAudioInputStream {
+  private signallingClient: SignallingClient;
+  private config: AgentAudioInputConfig;
+
+  constructor(
+    config: AgentAudioInputConfig,
+    signallingClient: SignallingClient,
+  ) {
+    this.config = config;
+    this.signallingClient = signallingClient;
+  }
+
+  /**
+   * Send PCM audio chunk to server.
+   * @param audioData - Raw PCM audio bytes
+   */
+  public sendAudioChunk(audioData: ArrayBuffer | Uint8Array): void {
+    const base64 = this.arrayBufferToBase64(audioData);
+
+    const payload: AgentAudioInputPayload = {
+      audioData: base64,
+      encoding: this.config.encoding,
+      sampleRate: this.config.sampleRate,
+      channels: this.config.channels,
+    };
+
+    this.signallingClient.sendAgentAudioInput(payload);
+  }
+
+  /**
+   * Signal end of the current audio sequence/turn.
+   * Sends AGENT_AUDIO_INPUT_END signal message.
+   */
+  public endSequence(): void {
+    this.signallingClient.sendAgentAudioInputEnd();
+  }
+
+  /**
+   * Get the audio format configuration for this stream.
+   */
+  public getConfig(): AgentAudioInputConfig {
+    return this.config;
+  }
+
+  private arrayBufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+    const bytes =
+      buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,4 @@ export type * from './events';
 export { AnamEvent } from './events'; // need to export this explicitly to avoid enum import issues
 export { InternalEvent } from './events'; // need to export this explicitly to avoid enum import issues
 export { ConnectionClosedCode } from './events'; // need to export this explicitly to avoid enum import issues
+export { AgentAudioInputStream } from './AgentAudioInputStream';

--- a/src/types/signalling/AgentAudioInputConfig.ts
+++ b/src/types/signalling/AgentAudioInputConfig.ts
@@ -1,0 +1,10 @@
+export interface AgentAudioInputConfig {
+  /** 'pcm_s16le' (16-bit signed) or 'pcm_f32le' (32-bit float) */
+  encoding: 'pcm_s16le' | 'pcm_f32le';
+
+  /** Sample rate in Hz (e.g., 16000, 24000, 44100) */
+  sampleRate: number;
+
+  /** 1 = mono, 2 = stereo */
+  channels: number;
+}

--- a/src/types/signalling/AgentAudioInputConfig.ts
+++ b/src/types/signalling/AgentAudioInputConfig.ts
@@ -1,6 +1,6 @@
 export interface AgentAudioInputConfig {
-  /** 'pcm_s16le' (16-bit signed) or 'pcm_f32le' (32-bit float) */
-  encoding: 'pcm_s16le' | 'pcm_f32le';
+  /** 'pcm_s16le' (16-bit signed) **/
+  encoding: 'pcm_s16le';
 
   /** Sample rate in Hz (e.g., 16000, 24000, 44100) */
   sampleRate: number;

--- a/src/types/signalling/AgentAudioInputPayload.ts
+++ b/src/types/signalling/AgentAudioInputPayload.ts
@@ -2,8 +2,8 @@ export interface AgentAudioInputPayload {
   /** Base64-encoded PCM audio data */
   audioData: string;
 
-  /** 'pcm_s16le' (16-bit signed) or 'pcm_f32le' (32-bit float) */
-  encoding: 'pcm_s16le' | 'pcm_f32le';
+  /** 'pcm_s16le' (16-bit signed) */
+  encoding: 'pcm_s16le';
 
   /** Sample rate in Hz (e.g., 16000, 24000, 44100) */
   sampleRate: number;

--- a/src/types/signalling/AgentAudioInputPayload.ts
+++ b/src/types/signalling/AgentAudioInputPayload.ts
@@ -3,7 +3,7 @@ export interface AgentAudioInputPayload {
   audioData: string;
 
   /** 'pcm_s16le' (16-bit signed) or 'pcm_f32le' (32-bit float) */
-  encoding: string;
+  encoding: 'pcm_s16le' | 'pcm_f32le';
 
   /** Sample rate in Hz (e.g., 16000, 24000, 44100) */
   sampleRate: number;

--- a/src/types/signalling/AgentAudioInputPayload.ts
+++ b/src/types/signalling/AgentAudioInputPayload.ts
@@ -1,0 +1,13 @@
+export interface AgentAudioInputPayload {
+  /** Base64-encoded PCM audio data */
+  audioData: string;
+
+  /** 'pcm_s16le' (16-bit signed) or 'pcm_f32le' (32-bit float) */
+  encoding: string;
+
+  /** Sample rate in Hz (e.g., 16000, 24000, 44100) */
+  sampleRate: number;
+
+  /** 1 = mono, 2 = stereo */
+  channels: number;
+}

--- a/src/types/signalling/AgentAudioInputPayload.ts
+++ b/src/types/signalling/AgentAudioInputPayload.ts
@@ -10,4 +10,7 @@ export interface AgentAudioInputPayload {
 
   /** 1 = mono, 2 = stereo */
   channels: number;
+
+  /** Sequence number for ordering (starts at 0, resets on endSequence) */
+  sequenceNumber: number;
 }

--- a/src/types/signalling/SignalMessage.ts
+++ b/src/types/signalling/SignalMessage.ts
@@ -8,6 +8,8 @@ export enum SignalMessageAction {
   TALK_STREAM_INTERRUPTED = 'talkinputstreaminterrupted',
   TALK_STREAM_INPUT = 'talkstream',
   SESSION_READY = 'sessionready',
+  AGENT_AUDIO_INPUT = 'agentaudioinput',
+  AGENT_AUDIO_INPUT_END = 'agentaudioinputend',
 }
 
 export interface SignalMessage {

--- a/src/types/signalling/index.ts
+++ b/src/types/signalling/index.ts
@@ -4,3 +4,5 @@ export type {
 } from './SignallingClientOptions';
 export type { SignalMessage } from './SignalMessage';
 export { SignalMessageAction } from './SignalMessage';
+export type { AgentAudioInputPayload } from './AgentAudioInputPayload';
+export type { AgentAudioInputConfig } from './AgentAudioInputConfig';


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an agent audio input stream for sending external PCM audio to the engine with base64 support and ordered chunks.

- **New Features**
  - AgentAudioInputStream: configurable (encoding, sampleRate, channels), accepts ArrayBuffer/Uint8Array/base64, supports endSequence.
  - New signalling actions: agentaudioinput and agentaudioinputend; send methods in SignallingClient; create/get stream in StreamingClient; createAgentAudioInputStream in AnamClient.

- **Bug Fixes**
  - Added sequenceNumber to audio payloads to ensure chunk ordering.

<sup>Written for commit 5f5b2db1f413be954d5900d1d2d93f0530573813. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









