### PR TITLE
feat: elevenlabs agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .DS_Store
-
+.idea/
 # Dependencies
 node_modules/
 

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -213,6 +213,7 @@ export default class AnamClient {
     const response: StartSessionResponse = await this.apiClient.startSession(
       config,
       sessionOptions,
+      this.clientOptions?.environment,
     );
     const {
       sessionId,

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -11,6 +11,7 @@ import {
   ApiGatewayConfig,
 } from '../types';
 import { StartSessionOptions } from '../types/coreApi/StartSessionOptions';
+import { ElevenLabsAgentSettings } from '../types/ElevenLabsAgentSettings';
 import { isCustomPersonaConfig } from '../types/PersonaConfig';
 
 export class CoreApiRestClient {
@@ -60,6 +61,7 @@ export class CoreApiRestClient {
   public async startSession(
     personaConfig?: PersonaConfig,
     sessionOptions?: StartSessionOptions,
+    environment?: { elevenLabsAgentSettings?: ElevenLabsAgentSettings },
   ): Promise<StartSessionResponse> {
     if (!this.sessionToken) {
       if (!personaConfig) {
@@ -69,7 +71,10 @@ export class CoreApiRestClient {
           400,
         );
       }
-      this.sessionToken = await this.unsafe_getSessionToken(personaConfig);
+      this.sessionToken = await this.unsafe_getSessionToken(
+        personaConfig,
+        environment,
+      );
     }
 
     // Check if brainType is being used and log deprecation warning
@@ -185,6 +190,7 @@ export class CoreApiRestClient {
 
   public async unsafe_getSessionToken(
     personaConfig: PersonaConfig,
+    environment?: { elevenLabsAgentSettings?: ElevenLabsAgentSettings },
   ): Promise<string> {
     console.warn(
       'Using unsecure method. This method should not be used in production.',
@@ -200,11 +206,18 @@ export class CoreApiRestClient {
       );
     }
 
-    let body: { clientLabel: string; personaConfig?: PersonaConfig } = {
+    let body: {
+      clientLabel: string;
+      personaConfig?: PersonaConfig;
+      environment?: { elevenLabsAgentSettings?: ElevenLabsAgentSettings };
+    } = {
       clientLabel: 'js-sdk-api-key',
     };
     if (isCustomPersonaConfig(personaConfig)) {
       body = { ...body, personaConfig };
+    }
+    if (environment) {
+      body = { ...body, environment };
     }
     try {
       const targetPath = `${this.apiVersion}/auth/session-token`;

--- a/src/types/AnamInternalClientOptions.ts
+++ b/src/types/AnamInternalClientOptions.ts
@@ -1,3 +1,8 @@
+import { ElevenLabsAgentSettings } from './ElevenLabsAgentSettings';
+
 export interface AnamInternalClientOptions {
   apiKey?: string;
+  environment?: {
+    elevenLabsAgentSettings?: ElevenLabsAgentSettings;
+  };
 }

--- a/src/types/ElevenLabsAgentSettings.ts
+++ b/src/types/ElevenLabsAgentSettings.ts
@@ -1,0 +1,4 @@
+export interface ElevenLabsAgentSettings {
+  signedUrl: string;
+  agentId: string;
+}

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -1,10 +1,10 @@
 export type PersonaConfig = CustomPersonaConfig;
 
 export interface CustomPersonaConfig {
-  personaId: string;
-  name: string;
+  personaId?: string;
+  name?: string;
   avatarId: string;
-  voiceId: string;
+  voiceId?: string;
   llmId?: string;
   systemPrompt?: string;
   maxSessionLengthSeconds?: number;
@@ -14,5 +14,9 @@ export interface CustomPersonaConfig {
 export function isCustomPersonaConfig(
   personaConfig: PersonaConfig,
 ): personaConfig is CustomPersonaConfig {
-  return 'brainType' in personaConfig || 'llmId' in personaConfig;
+  return (
+    'brainType' in personaConfig ||
+    'llmId' in personaConfig ||
+    'avatarId' in personaConfig
+  );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type * from './streaming';
 export { DataChannelMessage } from './streaming';
 export type * from './coreApi';
 export type { PersonaConfig } from './PersonaConfig';
+export type { ElevenLabsAgentSettings } from './ElevenLabsAgentSettings';
 export type { ApiGatewayConfig } from './ApiGatewayConfig';
 export type { InputAudioState } from './InputAudioState';
 export { AudioPermissionState } from './InputAudioState';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ElevenLabs agent support. The SDK can now send agent settings when starting a session so the Core API can initialize the voice agent.

- New Features
  - Added ElevenLabsAgentSettings { signedUrl, agentId } and exported it.
  - Added environment.elevenLabsAgentSettings to client options; passed from AnamClient to CoreApiRestClient.
  - Included environment in the auth/session-token request during startSession.
  - Relaxed PersonaConfig (personaId, name, voiceId now optional) and updated isCustomPersonaConfig to detect avatarId.

<sup>Written for commit 7784ff20b5edaa0a651272babf61a5a68b4c1ffa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

