### PR TITLE
Add Director Notes expressivity SDK API

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ const anamClient = createClient('your-session-token');
 
 ### Director notes and inline cues
 
-Use `personaConfig.directorNotes` to set the avatar's baseline presentation style for a session. Pick one preset style or provide a custom style.
+Use `personaConfig.directorNotes` to set the avatar's baseline presentation style for a session. Pick one preset style or provide a custom style. `speechAdherence` and `styleAdherence` are optional overrides; omit them to use the preset/custom defaults.
 
 ```typescript
 directorNotes: {
   presetStyle: 'supportive',
   speechAdherence: 1.35,
-  styleAdherence: 1.5,
+  styleAdherence: 1.3,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ directorNotes: {
 }
 ```
 
-You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn. The `[laughter]` cue triggers Cartesia laughter nonverbalism and uses playful avatar direction; `[rage]` uses high-intensity avatar direction.
+You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn. The `[laughter]` cue triggers Cartesia laughter nonverbalism and uses playful avatar direction.
 
 ```typescript
 await anamClient.talk(
-  '[happy] Great to see you. [laughter] [concerned] That sounds difficult. [rage] Enough.',
+  '[happy] Great to see you. [laughter] That surprised me. [angry] Enough.',
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ const anamClient = createClient('your-session-token');
 
 ### Director notes and inline cues
 
-Use `personaConfig.directorNotes` to set the avatar's baseline presentation style for a session. Pick one preset style or provide a custom style. `speechAdherence` and `styleAdherence` are optional overrides; omit them to use the preset/custom defaults.
+Use `personaConfig.directorNotes` to set the avatar's baseline presentation style for a session. Pick one preset style or provide a custom style. `expressivity` is an optional normalized value from `0` to `1`; omit it to use the preset/custom defaults.
 
 ```typescript
 directorNotes: {
   presetStyle: 'supportive',
-  speechAdherence: 1.35,
-  styleAdherence: 1.3,
+  expressivity: 0.35,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ const anamClient = unsafe_createClientWithApiKey('your-api-key', {
   avatarId: '30fa96d0-26c4-4e55-94a0-517025942e18',
   voiceId: '6bfbe25a-979d-40f3-a92b-5394170af54b',
   brainType: 'ANAM_GPT_4O_MINI_V1',
+  directorNotes: {
+    presetStyle: 'warm',
+  },
   systemPrompt:
     "[STYLE] Reply in natural speech without formatting. Add pauses using '...' and very occasionally a disfluency. [PERSONALITY] You are Cara, a helpful assistant.",
 });
@@ -89,6 +92,9 @@ const response = await fetch(`https://api.anam.ai/v1/auth/session-token`, {
       avatarId: '30fa96d0-26c4-4e55-94a0-517025942e18',
       voiceId: '6bfbe25a-979d-40f3-a92b-5394170af54b',
       llmId: '<LLM ID HERE>',
+      directorNotes: {
+        presetStyle: 'warm',
+      },
       systemPrompt:
         "[STYLE] Reply in natural speech without formatting. Add pauses using '...' and very occasionally a disfluency. [PERSONALITY] You are Cara, a helpful assistant.",
     },
@@ -104,6 +110,26 @@ Once you have a session token you can use the `createClient` method of the Anam 
 import { createClient } from '@anam-ai/js-sdk';
 
 const anamClient = createClient('your-session-token');
+```
+
+### Director notes and inline cues
+
+Use `personaConfig.directorNotes` to set the avatar's baseline presentation style for a session. Pick one preset style or provide a custom style.
+
+```typescript
+directorNotes: {
+  presetStyle: 'supportive',
+  speechAdherence: 1.35,
+  styleAdherence: 4.3,
+}
+```
+
+You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn.
+
+```typescript
+await anamClient.talk(
+  '[happy] Great to see you. [concerned] That sounds difficult.',
+);
 ```
 
 Regardless of whether you initialise the client using an API key or session token the client exposes the same set of available methods for streaming.

--- a/README.md
+++ b/README.md
@@ -120,15 +120,15 @@ Use `personaConfig.directorNotes` to set the avatar's baseline presentation styl
 directorNotes: {
   presetStyle: 'supportive',
   speechAdherence: 1.35,
-  styleAdherence: 4.3,
+  styleAdherence: 1.5,
 }
 ```
 
-You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn. The `[laughter]` cue triggers Cartesia laughter nonverbalism and uses playful avatar direction.
+You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn. The `[laughter]` cue triggers Cartesia laughter nonverbalism and uses playful avatar direction; `[rage]` uses high-intensity avatar direction.
 
 ```typescript
 await anamClient.talk(
-  '[happy] Great to see you. [laughter] [concerned] That sounds difficult.',
+  '[happy] Great to see you. [laughter] [concerned] That sounds difficult. [rage] Enough.',
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ directorNotes: {
 }
 ```
 
-You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn.
+You can also include basic emotion cue tags in `talk()` or `createTalkMessageStream()` text. Recognised cue tags are removed from spoken text and apply until the next cue tag or the end of the current turn. The `[laughter]` cue triggers Cartesia laughter nonverbalism and uses playful avatar direction.
 
 ```typescript
 await anamClient.talk(
-  '[happy] Great to see you. [concerned] That sounds difficult.',
+  '[happy] Great to see you. [laughter] [concerned] That sounds difficult.',
 );
 ```
 

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -11,8 +11,7 @@ export type DirectorNotesStylePreset =
   | 'disinterested'
   | 'confident'
   | 'enthusiastic'
-  | 'angry'
-  | 'rage';
+  | 'angry';
 
 export type DirectorNotes =
   | {

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -4,14 +4,15 @@ export type DirectorNotesStylePreset =
   | 'neutral'
   | 'warm'
   | 'supportive'
+  | 'curious'
   | 'serious'
+  | 'playful'
+  | 'distressed'
+  | 'disinterested'
   | 'confident'
   | 'enthusiastic'
-  | 'playful'
-  | 'curious'
-  | 'distressed'
   | 'angry'
-  | 'disinterested';
+  | 'rage';
 
 export type DirectorNotes =
   | {

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -17,14 +17,12 @@ export type DirectorNotes =
   | {
       presetStyle: DirectorNotesStylePreset;
       customStyle?: never;
-      speechAdherence?: number;
-      styleAdherence?: number;
+      expressivity?: number;
     }
   | {
       customStyle: string;
       presetStyle?: never;
-      speechAdherence?: number;
-      styleAdherence?: number;
+      expressivity?: number;
     };
 
 export interface CustomPersonaConfig {

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -16,11 +16,11 @@ export type DirectorNotesStylePreset =
 export type DirectorNotes =
   | {
       presetStyle: DirectorNotesStylePreset;
-      customStyle?: never;
+      customStylePrompt?: never;
       expressivity?: number;
     }
   | {
-      customStyle: string;
+      customStylePrompt: string;
       presetStyle?: never;
       expressivity?: number;
     };

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -1,5 +1,32 @@
 export type PersonaConfig = CustomPersonaConfig;
 
+export type DirectorNotesStylePreset =
+  | 'neutral'
+  | 'warm'
+  | 'supportive'
+  | 'serious'
+  | 'confident'
+  | 'enthusiastic'
+  | 'playful'
+  | 'curious'
+  | 'distressed'
+  | 'angry'
+  | 'disinterested';
+
+export type DirectorNotes =
+  | {
+      presetStyle: DirectorNotesStylePreset;
+      customStyle?: never;
+      speechAdherence?: number;
+      styleAdherence?: number;
+    }
+  | {
+      customStyle: string;
+      presetStyle?: never;
+      speechAdherence?: number;
+      styleAdherence?: number;
+    };
+
 export interface CustomPersonaConfig {
   personaId: string;
   name: string;
@@ -9,6 +36,7 @@ export interface CustomPersonaConfig {
   systemPrompt?: string;
   maxSessionLengthSeconds?: number;
   languageCode?: string;
+  directorNotes?: DirectorNotes;
 }
 
 export function isCustomPersonaConfig(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,11 @@ export { SignalMessageAction } from './signalling'; // need to export this expli
 export type * from './streaming';
 export { DataChannelMessage } from './streaming';
 export type * from './coreApi';
-export type { PersonaConfig } from './PersonaConfig';
+export type {
+  DirectorNotes,
+  DirectorNotesStylePreset,
+  PersonaConfig,
+} from './PersonaConfig';
 export type { ApiGatewayConfig } from './ApiGatewayConfig';
 export type { InputAudioState } from './InputAudioState';
 export { AudioPermissionState } from './InputAudioState';


### PR DESCRIPTION
## Summary
- Adds the SDK Director Notes type surface for preset/custom styles and inline cues.
- Exposes the public normalized `directorNotes.expressivity` field instead of the older two-value adherence/strength shape.
- Updates README examples to match the Lab/API/Engine expressivity interface.

## Validation
- `npm run build`
- `git diff --check`
