### PR TITLE
Add session video dimensions options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,22 @@ To use the SDK you first need to create an instance of `AnamClient`. For local d
 ```typescript
 import { unsafe_createClientWithApiKey } from '@anam-ai/js-sdk';
 
-const anamClient = unsafe_createClientWithApiKey('your-api-key', {
-  name: 'Cara',
-  avatarId: '30fa96d0-26c4-4e55-94a0-517025942e18',
-  voiceId: '6bfbe25a-979d-40f3-a92b-5394170af54b',
-  brainType: 'ANAM_GPT_4O_MINI_V1',
-  systemPrompt:
-    "[STYLE] Reply in natural speech without formatting. Add pauses using '...' and very occasionally a disfluency. [PERSONALITY] You are Cara, a helpful assistant.",
-});
+const anamClient = unsafe_createClientWithApiKey(
+  'your-api-key',
+  {
+    name: 'Cara',
+    avatarId: '30fa96d0-26c4-4e55-94a0-517025942e18',
+    voiceId: '6bfbe25a-979d-40f3-a92b-5394170af54b',
+    brainType: 'ANAM_GPT_4O_MINI_V1',
+    systemPrompt:
+      "[STYLE] Reply in natural speech without formatting. Add pauses using '...' and very occasionally a disfluency. [PERSONALITY] You are Cara, a helpful assistant.",
+  },
+  undefined,
+  {
+    videoWidth: 1152,
+    videoHeight: 768,
+  },
+);
 ```
 
 **NOTE**: the method `unsafe_createClientWithApiKey` is unsafe for production use cases because it requires exposing your api key to the client. When deploying to production see [production usage](#usage-in-production) first.
@@ -91,6 +99,10 @@ const response = await fetch(`https://api.anam.ai/v1/auth/session-token`, {
       llmId: '<LLM ID HERE>',
       systemPrompt:
         "[STYLE] Reply in natural speech without formatting. Add pauses using '...' and very occasionally a disfluency. [PERSONALITY] You are Cara, a helpful assistant.",
+    },
+    sessionOptions: {
+      videoWidth: 1152,
+      videoHeight: 768,
     },
   }),
 });

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -29,6 +29,7 @@ import {
   EventCallbacks,
   InputAudioState,
   PersonaConfig,
+  SessionOptions,
   StartSessionOptions,
   StartSessionResponse,
   ToolCallHandler,
@@ -63,6 +64,7 @@ export default class AnamClient {
     sessionToken: string | undefined,
     personaConfig?: PersonaConfig,
     options?: AnamClientOptions,
+    tokenSessionOptions?: SessionOptions,
   ) {
     const configError: string | undefined = this.validateClientConfig(
       sessionToken,
@@ -108,6 +110,7 @@ export default class AnamClient {
       sessionToken,
       options?.apiKey,
       options?.api,
+      tokenSessionOptions,
     );
     this.messageHistoryClient = new MessageHistoryClient(
       this.publicEventEmitter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import AnamClient from './AnamClient';
 import { PersonaConfig } from './types';
 import { AnamPublicClientOptions } from './types/AnamPublicClientOptions';
+import type { SessionOptions } from './types/coreApi/SessionOptions';
 import { ClientError, ErrorCode } from './lib/ClientError';
 
 /**
@@ -24,14 +25,21 @@ const createClient = (
  * @param apiKey - Your Anam API key.
  * @param personaConfig - The persona configuration to use.
  * @param options - Additional options.
+ * @param sessionOptions - Additional options to include when creating the session token.
  * @returns A new Anam client instance.
  */
 const unsafe_createClientWithApiKey = (
   apiKey: string,
   personaConfig: PersonaConfig,
   options?: AnamPublicClientOptions,
+  sessionOptions?: SessionOptions,
 ): AnamClient => {
-  return new AnamClient(undefined, personaConfig, { ...options, apiKey });
+  return new AnamClient(
+    undefined,
+    personaConfig,
+    { ...options, apiKey },
+    sessionOptions,
+  );
 };
 
 export { createClient, unsafe_createClientWithApiKey, ClientError, ErrorCode };

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -13,6 +13,7 @@ import {
   PersonaConfig,
   StartSessionResponse,
   ApiGatewayConfig,
+  SessionOptions,
 } from '../types';
 import { RetryOptions } from '../types/coreApi/ApiOptions';
 import { StartSessionOptions } from '../types/coreApi/StartSessionOptions';
@@ -32,8 +33,14 @@ export class CoreApiRestClient {
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private retryOptions: ResolvedRetryOptions;
   private requestTimeoutMs: number;
+  private tokenSessionOptions: SessionOptions | undefined;
 
-  constructor(sessionToken?: string, apiKey?: string, options?: ApiOptions) {
+  constructor(
+    sessionToken?: string,
+    apiKey?: string,
+    options?: ApiOptions,
+    tokenSessionOptions?: SessionOptions,
+  ) {
     if (!sessionToken && !apiKey) {
       throw new Error('Either sessionToken or apiKey must be provided');
     }
@@ -50,6 +57,7 @@ export class CoreApiRestClient {
         DEFAULT_START_SESSION_REQUEST_TIMEOUT_MS,
       ),
     );
+    this.tokenSessionOptions = tokenSessionOptions;
   }
 
   /**
@@ -90,7 +98,10 @@ export class CoreApiRestClient {
           400,
         );
       }
-      this.sessionToken = await this.unsafe_getSessionToken(personaConfig);
+      this.sessionToken = await this.unsafe_getSessionToken(
+        personaConfig,
+        this.tokenSessionOptions,
+      );
     }
 
     // Check if brainType is being used and log deprecation warning
@@ -248,6 +259,7 @@ export class CoreApiRestClient {
 
   public async unsafe_getSessionToken(
     personaConfig: PersonaConfig,
+    sessionOptions?: SessionOptions,
   ): Promise<string> {
     console.warn(
       'Using an insecure method. This method should not be used in production.',
@@ -263,11 +275,20 @@ export class CoreApiRestClient {
       );
     }
 
-    let body: { clientLabel: string; personaConfig?: PersonaConfig } = {
+    this.validateSessionOptions(sessionOptions);
+
+    let body: {
+      clientLabel: string;
+      personaConfig?: PersonaConfig;
+      sessionOptions?: SessionOptions;
+    } = {
       clientLabel: 'js-sdk-api-key',
     };
     if (isCustomPersonaConfig(personaConfig)) {
       body = { ...body, personaConfig };
+    }
+    if (sessionOptions) {
+      body = { ...body, sessionOptions };
     }
     try {
       const targetPath = `${this.apiVersion}/auth/session-token`;
@@ -290,6 +311,36 @@ export class CoreApiRestClient {
 
   private getApiUrl(): string {
     return `${this.baseUrl}${this.apiVersion}`;
+  }
+
+  private validateSessionOptions(sessionOptions?: SessionOptions): void {
+    if (!sessionOptions) {
+      return;
+    }
+
+    const hasVideoWidth = sessionOptions.videoWidth !== undefined;
+    const hasVideoHeight = sessionOptions.videoHeight !== undefined;
+
+    if (hasVideoWidth !== hasVideoHeight) {
+      throw new ClientError(
+        'videoWidth and videoHeight must be provided together',
+        ErrorCode.CLIENT_ERROR_CODE_VALIDATION_ERROR,
+        400,
+      );
+    }
+
+    for (const [name, value] of [
+      ['videoWidth', sessionOptions.videoWidth],
+      ['videoHeight', sessionOptions.videoHeight],
+    ] as const) {
+      if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+        throw new ClientError(
+          `${name} must be a positive integer`,
+          ErrorCode.CLIENT_ERROR_CODE_VALIDATION_ERROR,
+          400,
+        );
+      }
+    }
   }
 }
 

--- a/src/types/coreApi/SessionOptions.ts
+++ b/src/types/coreApi/SessionOptions.ts
@@ -1,0 +1,5 @@
+export interface SessionOptions {
+  videoQuality?: 'high' | 'auto';
+  videoWidth?: number;
+  videoHeight?: number;
+}

--- a/src/types/coreApi/index.ts
+++ b/src/types/coreApi/index.ts
@@ -6,3 +6,4 @@ export type {
   ClientConfigResponse,
 } from './StartSessionResponse';
 export { StartSessionOptions } from './StartSessionOptions';
+export type { SessionOptions } from './SessionOptions';


### PR DESCRIPTION
## Summary
- add a token-level SessionOptions type with videoQuality, videoWidth, and videoHeight
- pass token sessionOptions through the unsafe API-key token creation path only
- document server-side sessionOptions usage for production token creation

## Verification
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add session video size and quality controls to session token creation so apps can set output dimensions and quality. Supported in `unsafe_createClientWithApiKey` and documented for server-side token requests.

- **New Features**
  - Added `SessionOptions` with `videoQuality: 'high' | 'auto'`, `videoWidth`, and `videoHeight`.
  - `unsafe_createClientWithApiKey(apiKey, personaConfig, options?, sessionOptions?)` forwards `sessionOptions` to the token endpoint; these apply only at token creation.
  - Validation: `videoWidth` and `videoHeight` must be provided together and be positive integers; invalid input throws a 400 `ClientError`.
  - README updated with examples for local and production token creation including `sessionOptions`.

<sup>Written for commit e843d107389e5c0786be797e8ff3f38285e68fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

