### PR TITLE
feat(client): retry startSession on transient failures

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,3 +16,6 @@ export const CLIENT_METADATA = {
 export const DEFAULT_START_SESSION_MAX_ATTEMPTS = 3;
 export const DEFAULT_START_SESSION_INITIAL_BACKOFF_MS = 250;
 export const DEFAULT_START_SESSION_MAX_BACKOFF_MS = 2000;
+// Per-attempt timeout. Without this, a hung connection (no TCP reset)
+// would block the retry loop from ever firing.
+export const DEFAULT_START_SESSION_REQUEST_TIMEOUT_MS = 10000;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,3 +10,9 @@ export const CLIENT_METADATA = {
   client: 'js-sdk',
   version: '0.0.0-automated',
 };
+
+// Retry policy for startSession. Applied to transient failures only
+// (network errors and 5xx responses); 4xx responses are never retried.
+export const DEFAULT_START_SESSION_MAX_ATTEMPTS = 3;
+export const DEFAULT_START_SESSION_INITIAL_BACKOFF_MS = 250;
+export const DEFAULT_START_SESSION_MAX_BACKOFF_MS = 2000;

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_START_SESSION_INITIAL_BACKOFF_MS,
   DEFAULT_START_SESSION_MAX_ATTEMPTS,
   DEFAULT_START_SESSION_MAX_BACKOFF_MS,
+  DEFAULT_START_SESSION_REQUEST_TIMEOUT_MS,
 } from '../lib/constants';
 import {
   ApiOptions,
@@ -30,6 +31,7 @@ export class CoreApiRestClient {
   private sessionToken: string | null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private retryOptions: ResolvedRetryOptions;
+  private requestTimeoutMs: number;
 
   constructor(sessionToken?: string, apiKey?: string, options?: ApiOptions) {
     if (!sessionToken && !apiKey) {
@@ -41,6 +43,13 @@ export class CoreApiRestClient {
     this.apiVersion = options?.apiVersion || DEFAULT_API_VERSION;
     this.apiGatewayConfig = options?.apiGateway || undefined;
     this.retryOptions = resolveRetryOptions(options?.retry);
+    this.requestTimeoutMs = Math.max(
+      0,
+      asFiniteNumber(
+        options?.requestTimeoutMs,
+        DEFAULT_START_SESSION_REQUEST_TIMEOUT_MS,
+      ),
+    );
   }
 
   /**
@@ -111,6 +120,12 @@ export class CoreApiRestClient {
     personaConfig?: PersonaConfig,
     sessionOptions?: StartSessionOptions,
   ): Promise<StartSessionResponse> {
+    const controller =
+      this.requestTimeoutMs > 0 ? new AbortController() : undefined;
+    const timeoutHandle =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.requestTimeoutMs)
+        : undefined;
     try {
       const targetPath = `${this.apiVersion}/engine/session`;
       const { url, headers } = this.buildGatewayUrlAndHeaders(targetPath, {
@@ -126,6 +141,7 @@ export class CoreApiRestClient {
           sessionOptions,
           clientMetadata: CLIENT_METADATA,
         }),
+        signal: controller?.signal,
       });
 
       const data = await response.json();
@@ -212,6 +228,10 @@ export class CoreApiRestClient {
         500,
         { cause: error instanceof Error ? error.message : String(error) },
       );
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -214,7 +214,7 @@ export class CoreApiRestClient {
           throw new ClientError(
             'Unknown error when starting session',
             ErrorCode.CLIENT_ERROR_CODE_SERVER_ERROR,
-            500,
+            response.status,
             { cause: data.message },
           );
       }

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -3,6 +3,9 @@ import {
   CLIENT_METADATA,
   DEFAULT_API_BASE_URL,
   DEFAULT_API_VERSION,
+  DEFAULT_START_SESSION_INITIAL_BACKOFF_MS,
+  DEFAULT_START_SESSION_MAX_ATTEMPTS,
+  DEFAULT_START_SESSION_MAX_BACKOFF_MS,
 } from '../lib/constants';
 import {
   ApiOptions,
@@ -10,8 +13,15 @@ import {
   StartSessionResponse,
   ApiGatewayConfig,
 } from '../types';
+import { RetryOptions } from '../types/coreApi/ApiOptions';
 import { StartSessionOptions } from '../types/coreApi/StartSessionOptions';
 import { isCustomPersonaConfig } from '../types/PersonaConfig';
+
+interface ResolvedRetryOptions {
+  maxAttempts: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+}
 
 export class CoreApiRestClient {
   private baseUrl: string;
@@ -19,6 +29,7 @@ export class CoreApiRestClient {
   private apiKey: string | null;
   private sessionToken: string | null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
+  private retryOptions: ResolvedRetryOptions;
 
   constructor(sessionToken?: string, apiKey?: string, options?: ApiOptions) {
     if (!sessionToken && !apiKey) {
@@ -29,6 +40,7 @@ export class CoreApiRestClient {
     this.baseUrl = options?.baseUrl || DEFAULT_API_BASE_URL;
     this.apiVersion = options?.apiVersion || DEFAULT_API_VERSION;
     this.apiGatewayConfig = options?.apiGateway || undefined;
+    this.retryOptions = resolveRetryOptions(options?.retry);
   }
 
   /**
@@ -79,6 +91,26 @@ export class CoreApiRestClient {
       );
     }
 
+    const { maxAttempts } = this.retryOptions;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await this.attemptStartSession(personaConfig, sessionOptions);
+      } catch (error) {
+        lastError = error;
+        if (attempt >= maxAttempts || !isRetryableError(error)) {
+          throw error;
+        }
+        await sleep(this.computeBackoffDelay(attempt));
+      }
+    }
+    throw lastError;
+  }
+
+  private async attemptStartSession(
+    personaConfig?: PersonaConfig,
+    sessionOptions?: StartSessionOptions,
+  ): Promise<StartSessionResponse> {
     try {
       const targetPath = `${this.apiVersion}/engine/session`;
       const { url, headers } = this.buildGatewayUrlAndHeaders(targetPath, {
@@ -183,6 +215,17 @@ export class CoreApiRestClient {
     }
   }
 
+  private computeBackoffDelay(attempt: number): number {
+    const { initialBackoffMs, maxBackoffMs } = this.retryOptions;
+    const exponential = Math.min(
+      maxBackoffMs,
+      initialBackoffMs * Math.pow(2, attempt - 1),
+    );
+    // Equal jitter: half deterministic, half random. Avoids both thundering
+    // herd and zero-delay retries that would hammer a recovering origin.
+    return Math.floor(exponential / 2 + Math.random() * (exponential / 2));
+  }
+
   public async unsafe_getSessionToken(
     personaConfig: PersonaConfig,
   ): Promise<string> {
@@ -228,4 +271,33 @@ export class CoreApiRestClient {
   private getApiUrl(): string {
     return `${this.baseUrl}${this.apiVersion}`;
   }
+}
+
+function resolveRetryOptions(options?: RetryOptions): ResolvedRetryOptions {
+  const maxAttempts = Math.max(
+    1,
+    options?.maxAttempts ?? DEFAULT_START_SESSION_MAX_ATTEMPTS,
+  );
+  const initialBackoffMs = Math.max(
+    0,
+    options?.initialBackoffMs ?? DEFAULT_START_SESSION_INITIAL_BACKOFF_MS,
+  );
+  const maxBackoffMs = Math.max(
+    initialBackoffMs,
+    options?.maxBackoffMs ?? DEFAULT_START_SESSION_MAX_BACKOFF_MS,
+  );
+  return { maxAttempts, initialBackoffMs, maxBackoffMs };
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof ClientError) {
+    return error.statusCode >= 500 && error.statusCode < 600;
+  }
+  // Unwrapped errors (e.g. fetch network failures that escape attemptStartSession
+  // without being normalized to a ClientError) are treated as transient.
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/modules/CoreApiRestClient.ts
+++ b/src/modules/CoreApiRestClient.ts
@@ -274,19 +274,30 @@ export class CoreApiRestClient {
 }
 
 function resolveRetryOptions(options?: RetryOptions): ResolvedRetryOptions {
+  // NaN/Infinity would silently break the retry loop or remove the backoff
+  // cap, so coerce non-finite numerics back to the defaults before flooring.
   const maxAttempts = Math.max(
     1,
-    options?.maxAttempts ?? DEFAULT_START_SESSION_MAX_ATTEMPTS,
+    Math.floor(
+      asFiniteNumber(options?.maxAttempts, DEFAULT_START_SESSION_MAX_ATTEMPTS),
+    ),
   );
   const initialBackoffMs = Math.max(
     0,
-    options?.initialBackoffMs ?? DEFAULT_START_SESSION_INITIAL_BACKOFF_MS,
+    asFiniteNumber(
+      options?.initialBackoffMs,
+      DEFAULT_START_SESSION_INITIAL_BACKOFF_MS,
+    ),
   );
   const maxBackoffMs = Math.max(
     initialBackoffMs,
-    options?.maxBackoffMs ?? DEFAULT_START_SESSION_MAX_BACKOFF_MS,
+    asFiniteNumber(options?.maxBackoffMs, DEFAULT_START_SESSION_MAX_BACKOFF_MS),
   );
   return { maxAttempts, initialBackoffMs, maxBackoffMs };
+}
+
+function asFiniteNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
 function isRetryableError(error: unknown): boolean {

--- a/src/types/coreApi/ApiOptions.ts
+++ b/src/types/coreApi/ApiOptions.ts
@@ -26,4 +26,11 @@ export interface ApiOptions {
    * retried.
    */
   retry?: RetryOptions;
+  /**
+   * Per-attempt timeout for the session-start request, in milliseconds.
+   * If an attempt does not complete within this window it is aborted,
+   * which lets the retry policy treat the failure as transient. Set to 0
+   * to disable. Defaults to 10000.
+   */
+  requestTimeoutMs?: number;
 }

--- a/src/types/coreApi/ApiOptions.ts
+++ b/src/types/coreApi/ApiOptions.ts
@@ -1,7 +1,29 @@
 import { ApiGatewayConfig } from '../ApiGatewayConfig';
 
+export interface RetryOptions {
+  /**
+   * Total attempts including the first one. Set to 1 to disable retries.
+   */
+  maxAttempts?: number;
+  /**
+   * Initial backoff delay in milliseconds. Subsequent attempts use
+   * exponential backoff with jitter.
+   */
+  initialBackoffMs?: number;
+  /**
+   * Cap on the exponential backoff delay in milliseconds.
+   */
+  maxBackoffMs?: number;
+}
+
 export interface ApiOptions {
   baseUrl?: string;
   apiVersion?: string;
   apiGateway?: ApiGatewayConfig;
+  /**
+   * Retry policy for transient failures when starting a session.
+   * Applies to network errors and 5xx responses; 4xx responses are never
+   * retried.
+   */
+  retry?: RetryOptions;
 }

--- a/src/types/coreApi/index.ts
+++ b/src/types/coreApi/index.ts
@@ -1,4 +1,4 @@
-export type { ApiOptions } from './ApiOptions';
+export type { ApiOptions, RetryOptions } from './ApiOptions';
 // for backwards compatibility with deprecated name
 export type { ApiOptions as CoreApiOptions } from './ApiOptions';
 export type {


### PR DESCRIPTION
## Summary

`CoreApiRestClient.startSession` previously made a single `fetch` with no retry, so a transient network error (TCP drop, intermittent edge failure) or a 5xx response would fail the session immediately. This adds default exponential-backoff retries for the session-start request only. 4xx responses (validation, auth, plan/quota errors) are never retried.

## Changes

- New `RetryOptions` type, exposed via `ApiOptions.retry`, so callers can tighten, loosen, or disable the policy.
- Default policy: **3 attempts** total, **250ms** initial backoff, capped at **2s**, with equal jitter.
- `startSession` body extracted into a private `attemptStartSession`; the public method wraps it in a retry loop.
- Behaviour for terminal errors and the existing `ClientError` codes is unchanged.

Opt-out:

\`\`\`ts
new AnamClient({ apiKey, options: { retry: { maxAttempts: 1 } } });
\`\`\`

## Test plan

- [x] `npm run build` passes locally (tsc x2 + webpack UMD bundle).
- [ ] 4xx responses (400/401/402/403/429) still throw immediately with the same `ClientError` codes (verify in a follow-up integration test once a test harness exists).
- [ ] First-attempt network failure is retried up to `maxAttempts` and surfaces the final error to the caller.
- [ ] `apiOptions.retry.maxAttempts: 1` disables retries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exponential-backoff retries to `CoreApiRestClient.startSession` with a per-attempt timeout so transient failures and hung connections don’t fail or block the session on the first try.

- **New Features**
  - Default: 3 attempts, 250ms initial backoff, max 2s, equal jitter.
  - Retries only for network errors and 5xx; 4xx are never retried and preserve existing `ClientError` behavior.
  - Per-attempt timeout (default 10s) aborts stalled requests; configure with `ApiOptions.requestTimeoutMs` (0 disables).
  - Configurable via `ApiOptions.retry` (`RetryOptions`); set `maxAttempts: 1` to disable. Applies to `startSession` only.

- **Bug Fixes**
  - Coerces non-finite retry values (e.g., `NaN`, `Infinity`) to defaults and floors `maxAttempts`, preventing infinite loops or zero-delay backoffs.
  - Preserves `response.status` for unmapped errors so unmapped 4xx are not retried, while unmapped 5xx remain retryable.

<sup>Written for commit e5a3d5d62c550e28cde859538d2f94d3d27d7313. Summary will update on new commits. <a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

