### PR TITLE
feat: add directorNotes to session config (SDKJS-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,23 @@ directorNotes: {
   styleStrength: 1.2,
 }
 ```
+
+### Changing the style mid-session
+
+On Cara 4 you can change the style **without restarting** the session via `updateDirectorNotes`, for example to react to the conversation in real time. The engine applies `presetStyle` (pass `null` to reset to the session-start style) and the strength values immediately. `customStylePrompt` cannot be changed mid-session — start a new session to change it.
+
+```typescript
+// while the session is streaming:
+
+// switch to a different preset style
+anamClient.updateDirectorNotes({ presetStyle: 'happy' });
+
+// adjust how strongly the style / speech-driven motion are followed
+anamClient.updateDirectorNotes({
+  styleStrength: 1.5,
+  speechMotionStrength: 1.2,
+});
+
+// reset to the style the session started with
+anamClient.updateDirectorNotes({ presetStyle: null });
+```

--- a/README.md
+++ b/README.md
@@ -109,3 +109,36 @@ const anamClient = createClient('your-session-token');
 Regardless of whether you initialise the client using an API key or session token the client exposes the same set of available methods for streaming.
 
 [See here](#starting-a-session-in-production-environments) for an example sequence diagram of starting a session in production environments.
+
+## Director Notes (Cara 4)
+
+On Cara 4 avatars you can add **Director Notes** to guide the avatar's performance style and speech-driven motion. Provide either a built-in `presetStyle` **or** a free-form `customStylePrompt` — the two are mutually exclusive (enforced by the `DirectorNotes` type) — plus optional CFG-style strength values where `1.0` is the default. Director Notes are forwarded unchanged to session-token creation and are only applied on Cara 4 avatars; on older models the server ignores them and the session proceeds without them.
+
+```typescript
+import { unsafe_createClientWithApiKey } from '@anam-ai/js-sdk';
+
+const anamClient = unsafe_createClientWithApiKey('your-api-key', {
+  name: 'Cara',
+  // Use a Cara 4 avatar — Director Notes are ignored on older models.
+  avatarId: '30fa96d0-26c4-4e55-94a0-517025942e18',
+  voiceId: '6bfbe25a-979d-40f3-a92b-5394170af54b',
+  llmId: '<LLM ID HERE>',
+  systemPrompt:
+    '[STYLE] Reply in natural speech without formatting. [PERSONALITY] You are Cara, a helpful assistant.',
+  directorNotes: {
+    presetStyle: 'warm',
+    styleStrength: 1.2,
+    speechMotionStrength: 1.0,
+  },
+});
+```
+
+To use a free-form style instead of a preset, provide `customStylePrompt`:
+
+```typescript
+directorNotes: {
+  customStylePrompt:
+    'Warm smile, composed, slightly amused, looking directly at camera',
+  styleStrength: 1.2,
+}
+```

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -29,6 +29,7 @@ import {
   EventCallbacks,
   InputAudioState,
   PersonaConfig,
+  RuntimeDirectorNotes,
   StartSessionOptions,
   StartSessionResponse,
   ToolCallHandler,
@@ -544,6 +545,34 @@ export default class AnamClient {
       message_type: 'context',
       session_id: sessionId,
       content,
+    });
+
+    this.sendDataMessage(body);
+  }
+
+  /**
+   * Update Director Notes on the active streaming session, applied without
+   * restarting (Cara 4 avatars only).
+   *
+   * Forwarded over the data channel; the engine applies `presetStyle` (pass
+   * `null` to reset to the session-start style) and the strength values
+   * immediately. `customStylePrompt` cannot be changed mid-session — start a
+   * new session to change it. No-op on non-Cara-4 avatars or engines that don't
+   * support dynamic updates.
+   *
+   * @param directorNotes - Partial update; send only the fields that change.
+   * @throws Error if not currently streaming
+   */
+  public updateDirectorNotes(directorNotes: RuntimeDirectorNotes): void {
+    if (!this._isStreaming) {
+      throw new Error(
+        'Failed to update director notes: not currently streaming',
+      );
+    }
+
+    const body = JSON.stringify({
+      message_type: 'persona_config',
+      data: { directorNotes },
     });
 
     this.sendDataMessage(body);

--- a/src/types/DirectorNotes.ts
+++ b/src/types/DirectorNotes.ts
@@ -1,0 +1,64 @@
+/**
+ * Director Notes guide a Cara 4 avatar's performance style and speech-driven
+ * motion for a session. They are forwarded unchanged to session-token
+ * creation and are only applied on Cara 4 avatars; on older models the server
+ * ignores them and the session proceeds without them.
+ *
+ * `presetStyle` and `customStylePrompt` are mutually exclusive — the exclusive
+ * union below enforces that at the type level, so providing both is a compile
+ * error. The server remains the source of truth for model-compatibility
+ * validation.
+ */
+
+/**
+ * Built-in performance styles the avatar can follow.
+ *
+ * Hand-maintained MIRROR of the engine's accepted cue tags
+ * (`_DIRECTOR_NOTE_CUE_PROMPT_NAMES` in anam-org/anam-engine
+ * `anam_engine/director_notes/cues.py`) — there is no runtime sync, so this can
+ * drift. The server ignores unknown styles. Keep in sync with the engine and
+ * with the Lab's `PRESET_STYLES` (anam-org/anam-lab) when styles change.
+ */
+export type PresetStyle =
+  | 'happy'
+  | 'warm'
+  | 'playful'
+  | 'laughter'
+  | 'curious'
+  | 'supportive'
+  | 'concerned'
+  | 'sad'
+  | 'surprised'
+  | 'angry'
+  | 'distressed';
+
+interface DirectorNotesStrengths {
+  /**
+   * How strongly the avatar follows the selected style. CFG-style guidance
+   * value; 1.0 is the default.
+   */
+  styleStrength?: number;
+  /**
+   * How strongly the avatar's motion follows the speech signal. CFG-style
+   * guidance value; 1.0 is the default.
+   */
+  speechMotionStrength?: number;
+}
+
+export type DirectorNotes =
+  | (DirectorNotesStrengths & {
+      /**
+       * Built-in performance style for the avatar to follow. Mutually
+       * exclusive with `customStylePrompt`.
+       */
+      presetStyle: PresetStyle;
+      customStylePrompt?: never;
+    })
+  | (DirectorNotesStrengths & {
+      /**
+       * Free-form performance style prompt for the avatar to follow. Mutually
+       * exclusive with `presetStyle`.
+       */
+      customStylePrompt: string;
+      presetStyle?: never;
+    });

--- a/src/types/DirectorNotes.ts
+++ b/src/types/DirectorNotes.ts
@@ -62,3 +62,18 @@ export type DirectorNotes =
       customStylePrompt: string;
       presetStyle?: never;
     });
+
+/**
+ * Partial Director Notes update for a LIVE (streaming) session, applied via
+ * {@link AnamClient.updateDirectorNotes} over the data channel. All fields are
+ * optional — send only what changes.
+ *
+ * Only Cara 4 avatars support mid-session updates, and the engine applies only
+ * `presetStyle` and the strength values live. `presetStyle: null` resets to the
+ * session-start style. `customStylePrompt` cannot be changed mid-session (start
+ * a new session to change it), so it is intentionally not part of this type.
+ * No-op on engines that don't support dynamic updates.
+ */
+export interface RuntimeDirectorNotes extends DirectorNotesStrengths {
+  presetStyle?: PresetStyle | null;
+}

--- a/src/types/PersonaConfig.ts
+++ b/src/types/PersonaConfig.ts
@@ -1,3 +1,5 @@
+import { DirectorNotes } from './DirectorNotes';
+
 export type PersonaConfig = CustomPersonaConfig;
 
 export interface CustomPersonaConfig {
@@ -9,6 +11,12 @@ export interface CustomPersonaConfig {
   systemPrompt?: string;
   maxSessionLengthSeconds?: number;
   languageCode?: string;
+  /**
+   * Director Notes for the session — guides the avatar's performance style and
+   * speech-driven motion. Cara 4 avatars only; forwarded unchanged to
+   * session-token creation. See {@link DirectorNotes}.
+   */
+  directorNotes?: DirectorNotes;
 }
 
 export function isCustomPersonaConfig(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,11 @@ export type * from './streaming';
 export { DataChannelMessage } from './streaming';
 export type * from './coreApi';
 export type { PersonaConfig } from './PersonaConfig';
-export type { DirectorNotes, PresetStyle } from './DirectorNotes';
+export type {
+  DirectorNotes,
+  PresetStyle,
+  RuntimeDirectorNotes,
+} from './DirectorNotes';
 export type { ApiGatewayConfig } from './ApiGatewayConfig';
 export type { InputAudioState } from './InputAudioState';
 export { AudioPermissionState } from './InputAudioState';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type * from './streaming';
 export { DataChannelMessage } from './streaming';
 export type * from './coreApi';
 export type { PersonaConfig } from './PersonaConfig';
+export type { DirectorNotes, PresetStyle } from './DirectorNotes';
 export type { ApiGatewayConfig } from './ApiGatewayConfig';
 export type { InputAudioState } from './InputAudioState';
 export { AudioPermissionState } from './InputAudioState';


### PR DESCRIPTION
## What

Adds support for **Director Notes** in the session/persona config so SDK consumers can guide a Cara 4 avatar's performance style and speech-driven motion. Part of the Cara 4 release; mirrors the Lab API contract.

## Changes

- New `src/types/DirectorNotes.ts` exporting `DirectorNotes` and `PresetStyle`.
- `directorNotes?: DirectorNotes` added to `CustomPersonaConfig`.
- Exported `DirectorNotes` / `PresetStyle` from the public types barrel for consumer autocomplete.
- README: a Cara 4 + Director Notes example (both `presetStyle` and `customStylePrompt`).

## API shape

```ts
type DirectorNotes =
  | { presetStyle: PresetStyle; styleStrength?: number; speechMotionStrength?: number }
  | { customStylePrompt: string; styleStrength?: number; speechMotionStrength?: number };
```

`presetStyle` and `customStylePrompt` are **mutually exclusive**, enforced at the type level via an exclusive union (`?: never`) — providing both, or neither, is a compile error. Strength values are optional CFG-style guidance (`1.0` default).

## Forwarding

No client changes were needed: `personaConfig` is already forwarded **verbatim** to `/v1/auth/session-token` (`unsafe_getSessionToken`) and to the engine session (`startSession` → `attemptStartSession`), so `directorNotes` flows through unchanged — the same pattern as the rest of `personaConfig`.

## Validation

Client-side validation is kept light (the type-level mutex). The **server is the source of truth** for model-compatibility (rejects Director Notes on Cara 3 / older avatars).

## Out of scope

- LiveKit Agent / Python SDK.
- Plan-based gating.
- An `avatarModel` override field is not part of this SDK (the avatar's own model determines Cara 4 eligibility); not in scope for this ticket.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Verified the exclusive union rejects both-set and neither-set at compile time (`@ts-expect-error`)

Companion: Lab API ticket LAB-112 (defines `DirectorNotes` + server validation), Lab UI ticket LAB-111.

Closes SDKJS-4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `directorNotes` to session persona config and a new `updateDirectorNotes` API for mid-session style changes on Cara 4. Mirrors the Lab API and satisfies SDKJS-4.

- **New Features**
  - Added `DirectorNotes` and `PresetStyle` types with an exclusive union (`presetStyle` or `customStylePrompt`) and optional `styleStrength`/`speechMotionStrength` (default 1.0).
  - Added `directorNotes?: DirectorNotes` to `CustomPersonaConfig`; forwarded unchanged to `/v1/auth/session-token` and the engine session; applied only on Cara 4.
  - Added `AnamClient.updateDirectorNotes(directorNotes: RuntimeDirectorNotes)` to change preset style or strengths live (pass `null` to reset); rejects when not streaming; `customStylePrompt` is not runtime-updatable; no-op on non‑Cara‑4.
  - Exported `DirectorNotes`/`PresetStyle`/`RuntimeDirectorNotes`; README includes examples for preset, custom, and live updates.

<sup>Written for commit a9c045fc8bb11295e60801dbd4126a72ae3ac52d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

