### PR TITLE
feat(client): add rtcConfiguration passthrough option

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -240,10 +240,12 @@ export default class AnamClient {
       sessionId: this.sessionId,
     });
 
-    // Use custom ICE servers if provided, otherwise use server-provided ICE servers
-    const iceServers = this.clientOptions?.iceServers
-      ? this.clientOptions.iceServers
-      : defaultIceServers;
+    // Use custom ICE servers if provided, otherwise use server-provided ICE servers.
+    // Precedence: top-level `iceServers` > `rtcConfiguration.iceServers` > server default.
+    const iceServers =
+      this.clientOptions?.iceServers ??
+      this.clientOptions?.rtcConfiguration?.iceServers ??
+      defaultIceServers;
 
     try {
       this.streamingClient = new StreamingClient(
@@ -262,6 +264,7 @@ export default class AnamClient {
             },
           },
           iceServers,
+          rtcConfiguration: this.clientOptions?.rtcConfiguration,
           inputAudio: {
             inputAudioState: this.inputAudioState,
             userProvidedMediaStream: this.clientOptions?.disableInputAudio

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -46,6 +46,7 @@ export class StreamingClient {
   private signallingClient: SignallingClient;
   private engineApiRestClient: EngineApiRestClient;
   private iceServers: RTCIceServer[];
+  private rtcConfiguration: RTCConfiguration | undefined;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private peerConnection: RTCPeerConnection | null = null;
   private connectionReceivedAnswer = false;
@@ -120,6 +121,7 @@ export class StreamingClient {
     );
     // set ice servers
     this.iceServers = options.iceServers;
+    this.rtcConfiguration = options.rtcConfiguration;
     // initialize signalling client
     this.signallingClient = new SignallingClient(
       sessionId,
@@ -483,8 +485,12 @@ export class StreamingClient {
 
   private async initPeerConnection() {
     this.peerConnection = new RTCPeerConnection({
-      iceServers: this.iceServers,
+      // SDK default first (caller's rtcConfiguration may override it)
       iceCandidatePoolSize: ICE_CANDIDATE_POOL_SIZE,
+      // caller's full RTCConfiguration passthrough (e.g. iceTransportPolicy: 'relay')
+      ...this.rtcConfiguration,
+      // resolved iceServers always wins for its field (preserves backward compat)
+      iceServers: this.iceServers,
     });
     // set event handlers
     this.peerConnection.onicecandidate = this.onIceCandidate.bind(this);

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -17,4 +17,11 @@ export interface AnamPublicClientOptions {
     disableClientMetrics?: boolean;
   };
   iceServers?: RTCIceServer[];
+  /**
+   * Full RTCConfiguration passed through to the underlying RTCPeerConnection.
+   * Use e.g. `{ iceTransportPolicy: 'relay' }` to force TURN-relay-only on
+   * networks that drop UDP. The top-level `iceServers` option (when set) takes
+   * precedence over `rtcConfiguration.iceServers`.
+   */
+  rtcConfiguration?: RTCConfiguration;
 }

--- a/src/types/streaming/StreamingClientOptions.ts
+++ b/src/types/streaming/StreamingClientOptions.ts
@@ -7,6 +7,7 @@ export interface StreamingClientOptions {
   engine: EngineApiRestClientOptions;
   signalling: SignallingClientOptions;
   iceServers: RTCIceServer[];
+  rtcConfiguration?: RTCConfiguration;
   inputAudio: InputAudioOptions;
   apiGateway?: ApiGatewayConfig;
   metrics?: {


### PR DESCRIPTION
## Summary
- Add an optional `rtcConfiguration?: RTCConfiguration` to `AnamPublicClientOptions`, passed through to the underlying `RTCPeerConnection`.
- Enables forcing TURN-relay-only (e.g. `{ iceTransportPolicy: 'relay' }`) on networks that drop UDP, plus any other native `RTCConfiguration` fields.
- ICE server precedence: top-level `iceServers` > `rtcConfiguration.iceServers` > server-provided default.
- Resolved `iceServers` always wins for its field in `initPeerConnection`, preserving backward compatibility.

## Test plan
- [ ] Connect with no `rtcConfiguration` set — behaviour unchanged, server/default ICE servers used.
- [ ] Pass `rtcConfiguration: { iceTransportPolicy: 'relay' }` and confirm the peer connection only uses TURN relay candidates.
- [ ] Pass `rtcConfiguration.iceServers` only (no top-level `iceServers`) and confirm those servers are used.
- [ ] Pass both top-level `iceServers` and `rtcConfiguration.iceServers` and confirm the top-level value wins.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `rtcConfiguration` passthrough to client options so apps can control the underlying `RTCPeerConnection` (e.g., force TURN relay-only).

- **New Features**
  - Added `rtcConfiguration?: RTCConfiguration` to `AnamPublicClientOptions` and `StreamingClientOptions`, passed through on peer connection init.
  - ICE server precedence: top-level `iceServers` > `rtcConfiguration.iceServers` > server default; resolved `iceServers` wins in `initPeerConnection` to preserve compatibility.

<sup>Written for commit c9c20ceff2d2896134866f86ae1e122e6977b197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

