### PR TITLE
ENG-1118 Add SDK ICE restart recovery

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -231,8 +231,11 @@ export default class AnamClient {
     const {
       heartbeatIntervalSeconds,
       maxWsReconnectionAttempts,
+      maxWsReconnectAttempts,
       iceServers: defaultIceServers,
     } = clientConfig;
+    const resolvedMaxWsReconnectionAttempts =
+      maxWsReconnectionAttempts ?? maxWsReconnectAttempts;
 
     this.sessionId = sessionId;
     this.toolCallManager.setActiveSession(sessionId);
@@ -256,7 +259,7 @@ export default class AnamClient {
           },
           signalling: {
             heartbeatIntervalSeconds,
-            maxWsReconnectionAttempts,
+            maxWsReconnectionAttempts: resolvedMaxWsReconnectionAttempts,
             url: {
               baseUrl: engineHost,
               protocol: engineProtocol,

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -13,6 +13,8 @@ import { TalkMessageStreamPayload } from '../types/signalling/TalkMessageStreamP
 
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5;
 const DEFAULT_WS_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_WS_RECOVERY_WINDOW_MS = 15000;
+const MAX_WS_RECONNECT_DELAY_MS = 1000;
 
 export class SignallingClient {
   private publicEventEmitter: PublicEventEmitter;
@@ -24,6 +26,7 @@ export class SignallingClient {
   private stopSignal = false;
   private sendingBuffer: SignalMessage[] = [];
   private wsConnectionAttempts = 0;
+  private wsReconnectStartedAt: number | null = null;
   private socket: WebSocket | null = null;
   private heartBeatIntervalRef: ReturnType<typeof setInterval> | null = null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
@@ -44,14 +47,20 @@ export class SignallingClient {
     }
     this.sessionId = sessionId;
 
-    const { heartbeatIntervalSeconds, maxWsReconnectionAttempts, url } =
-      options;
+    const {
+      heartbeatIntervalSeconds,
+      maxWsReconnectionAttempts,
+      maxWsReconnectAttempts,
+      url,
+    } = options;
 
     this.heartbeatIntervalSeconds =
       heartbeatIntervalSeconds || DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
 
     this.maxWsReconnectionAttempts =
-      maxWsReconnectionAttempts || DEFAULT_WS_RECONNECTION_ATTEMPTS;
+      maxWsReconnectionAttempts ||
+      maxWsReconnectAttempts ||
+      DEFAULT_WS_RECONNECTION_ATTEMPTS;
 
     if (!url.baseUrl) {
       throw new Error('Signalling Client: baseUrl is required');
@@ -125,6 +134,24 @@ export class SignallingClient {
     this.sendSignalMessage(offerMessage);
   }
 
+  public async sendAnswer(localDescription: RTCSessionDescriptionInit) {
+    const answerMessage: SignalMessage = {
+      actionType: SignalMessageAction.ANSWER,
+      sessionId: this.sessionId,
+      payload: localDescription,
+    };
+    this.sendSignalMessage(answerMessage);
+  }
+
+  public sendIceRestartRequest() {
+    const iceRestartRequestMessage: SignalMessage = {
+      actionType: SignalMessageAction.ICE_RESTART_REQUEST,
+      sessionId: this.sessionId,
+      payload: {},
+    };
+    this.sendSignalMessage(iceRestartRequestMessage);
+  }
+
   public async sendIceCandidate(candidate: RTCIceCandidate) {
     const iceCandidateMessage: SignalMessage = {
       actionType: SignalMessageAction.ICE_CANDIDATE,
@@ -138,14 +165,18 @@ export class SignallingClient {
     if (this.socket?.readyState === WebSocket.OPEN) {
       try {
         this.socket.send(JSON.stringify(message));
+        this.logIceRestartSignalMessage(message, 'sent');
       } catch (error) {
         console.error(
           'SignallingClient - sendSignalMessage: error sending message',
           error,
         );
+        this.sendingBuffer.push(message);
+        this.logIceRestartSignalMessage(message, 'queued after send error');
       }
     } else {
       this.sendingBuffer.push(message);
+      this.logIceRestartSignalMessage(message, 'queued while websocket closed');
     }
   }
 
@@ -187,12 +218,47 @@ export class SignallingClient {
     }
   }
 
+  public reconnect() {
+    if (this.stopSignal) {
+      return;
+    }
+
+    console.info('SignallingClient - reconnect: reconnecting websocket', {
+      sessionId: this.sessionId,
+      readyState: this.socket?.readyState,
+      bufferedMessages: this.sendingBuffer.length,
+    });
+
+    if (this.socket) {
+      this.socket.onclose = null;
+      this.socket.onerror = null;
+      this.socket.onmessage = null;
+      this.socket.onopen = null;
+      try {
+        this.socket.close();
+      } catch (error) {
+        console.error(
+          'SignallingClient - reconnect: error closing socket',
+          error,
+        );
+      }
+      this.socket = null;
+    }
+    if (this.heartBeatIntervalRef) {
+      clearInterval(this.heartBeatIntervalRef);
+      this.heartBeatIntervalRef = null;
+    }
+
+    this.connect();
+  }
+
   private async onOpen(): Promise<void> {
     if (!this.socket) {
       throw new Error('SignallingClient - onOpen: socket is null');
     }
     try {
       this.wsConnectionAttempts = 0;
+      this.wsReconnectStartedAt = null;
       this.flushSendingBuffer();
       this.socket.onmessage = this.onMessage.bind(this);
       this.startSendingHeartBeats();
@@ -211,16 +277,27 @@ export class SignallingClient {
     if (this.stopSignal) {
       return;
     }
-    if (this.wsConnectionAttempts <= this.maxWsReconnectionAttempts) {
+    if (this.heartBeatIntervalRef) {
+      clearInterval(this.heartBeatIntervalRef);
+      this.heartBeatIntervalRef = null;
+    }
+    if (!this.wsReconnectStartedAt) {
+      this.wsReconnectStartedAt = Date.now();
+    }
+    const elapsedReconnectMs = Date.now() - this.wsReconnectStartedAt;
+    const shouldReconnect =
+      this.wsConnectionAttempts <= this.maxWsReconnectionAttempts ||
+      elapsedReconnectMs < DEFAULT_WS_RECOVERY_WINDOW_MS;
+
+    if (shouldReconnect) {
       this.socket = null;
-      setTimeout(() => {
-        this.connect();
-      }, 100 * this.wsConnectionAttempts);
+      setTimeout(
+        () => {
+          this.connect();
+        },
+        Math.min(100 * this.wsConnectionAttempts, MAX_WS_RECONNECT_DELAY_MS),
+      );
     } else {
-      if (this.heartBeatIntervalRef) {
-        clearInterval(this.heartBeatIntervalRef);
-        this.heartBeatIntervalRef = null;
-      }
       this.publicEventEmitter.emit(
         AnamEvent.CONNECTION_CLOSED,
         ConnectionClosedCode.SIGNALLING_CLIENT_CONNECTION_FAILURE,
@@ -241,12 +318,25 @@ export class SignallingClient {
       this.sendingBuffer.forEach((message: SignalMessage) => {
         if (this.socket?.readyState === WebSocket.OPEN) {
           this.socket.send(JSON.stringify(message));
+          this.logIceRestartSignalMessage(message, 'flushed');
         } else {
           newBuffer.push(message);
         }
       });
     }
     this.sendingBuffer = newBuffer;
+  }
+
+  private logIceRestartSignalMessage(message: SignalMessage, state: string) {
+    if (message.actionType !== SignalMessageAction.ICE_RESTART_REQUEST) {
+      return;
+    }
+
+    console.info('SignallingClient - ICE restart request ' + state, {
+      sessionId: this.sessionId,
+      readyState: this.socket?.readyState,
+      bufferedMessages: this.sendingBuffer.length,
+    });
   }
 
   private async onMessage(event: MessageEvent) {

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -39,8 +39,10 @@ import { ToolCallManager } from './ToolCallManager';
 const SUCCESS_METRIC_POLLING_TIMEOUT_MS = 15000; // After this time we will stop polling for the first frame and consider the session a failure.
 const STATS_COLLECTION_INTERVAL_MS = 5000;
 const ICE_CANDIDATE_POOL_SIZE = 2; // Optimisation to speed up connection time
+const ICE_RESTART_REQUEST_RETRY_INTERVAL_MS = 1000;
 
 export class StreamingClient {
+  private sessionId: string;
   private publicEventEmitter: PublicEventEmitter;
   private internalEventEmitter: InternalEventEmitter;
   private signallingClient: SignallingClient;
@@ -50,6 +52,12 @@ export class StreamingClient {
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private peerConnection: RTCPeerConnection | null = null;
   private connectionReceivedAnswer = false;
+  private hasEstablishedConnection = false;
+  private iceRestartInProgress = false;
+  private waitingForIceRestartOffer = false;
+  private iceRestartRequestRetryInterval: ReturnType<
+    typeof setInterval
+  > | null = null;
   private remoteIceCandidateBuffer: RTCIceCandidate[] = [];
   private inputAudioStream: MediaStream | null = null;
   private dataChannel: RTCDataChannel | null = null;
@@ -77,6 +85,7 @@ export class StreamingClient {
     internalEventEmitter: InternalEventEmitter,
     toolCallManager: ToolCallManager,
   ) {
+    this.sessionId = sessionId;
     this.publicEventEmitter = publicEventEmitter;
     this.internalEventEmitter = internalEventEmitter;
     this.toolCallManager = toolCallManager;
@@ -484,6 +493,13 @@ export class StreamingClient {
   }
 
   private async initPeerConnection() {
+    this.connectionReceivedAnswer = false;
+    this.hasEstablishedConnection = false;
+    this.iceRestartInProgress = false;
+    this.waitingForIceRestartOffer = false;
+    this.stopIceRestartRequestRetry();
+    this.remoteIceCandidateBuffer = [];
+
     this.peerConnection = new RTCPeerConnection({
       // SDK default first (caller's rtcConfiguration may override it)
       iceCandidatePoolSize: ICE_CANDIDATE_POOL_SIZE,
@@ -540,12 +556,30 @@ export class StreamingClient {
         await this.peerConnection.setRemoteDescription(answer);
         this.connectionReceivedAnswer = true;
         // flush the remote buffer
-        this.flushRemoteIceCandidateBuffer();
+        await this.flushRemoteIceCandidateBuffer();
+        break;
+      case SignalMessageAction.OFFER:
+        const offer = signalMessage.payload as RTCSessionDescriptionInit;
+        await this.peerConnection.setRemoteDescription(offer);
+        await this.flushRemoteIceCandidateBuffer();
+        const restartAnswer = await this.peerConnection.createAnswer();
+        await this.peerConnection.setLocalDescription(restartAnswer);
+        if (!this.peerConnection.localDescription) {
+          throw new Error(
+            'StreamingClient - onSignalMessage: local description is null after ICE restart answer',
+          );
+        }
+        await this.signallingClient.sendAnswer(
+          this.peerConnection.localDescription,
+        );
+        this.waitingForIceRestartOffer = false;
+        this.stopIceRestartRequestRetry();
+        await this.flushRemoteIceCandidateBuffer();
         break;
       case SignalMessageAction.ICE_CANDIDATE:
         const iceCandidateConfig = signalMessage.payload as RTCIceCandidateInit;
         const candidate = new RTCIceCandidate(iceCandidateConfig);
-        if (this.connectionReceivedAnswer) {
+        if (this.connectionReceivedAnswer && !this.waitingForIceRestartOffer) {
           await this.peerConnection.addIceCandidate(candidate);
         } else {
           this.remoteIceCandidateBuffer.push(candidate);
@@ -599,14 +633,24 @@ export class StreamingClient {
         );
         this.handleWebrtcFailure(err);
       }
+    } else if (this.waitingForIceRestartOffer) {
+      this.signallingClient.sendIceRestartRequest();
     }
   }
 
-  private flushRemoteIceCandidateBuffer() {
-    this.remoteIceCandidateBuffer.forEach((candidate) => {
-      this.peerConnection?.addIceCandidate(candidate);
-    });
+  private async flushRemoteIceCandidateBuffer() {
+    const bufferedCandidates = this.remoteIceCandidateBuffer;
     this.remoteIceCandidateBuffer = [];
+    for (const candidate of bufferedCandidates) {
+      try {
+        await this.peerConnection?.addIceCandidate(candidate);
+      } catch (error) {
+        console.warn(
+          'StreamingClient - flushRemoteIceCandidateBuffer: error adding ICE candidate',
+          error,
+        );
+      }
+    }
   }
 
   /**
@@ -625,14 +669,79 @@ export class StreamingClient {
       this.peerConnection?.iceConnectionState === 'connected' ||
       this.peerConnection?.iceConnectionState === 'completed'
     ) {
+      this.hasEstablishedConnection = true;
+      this.iceRestartInProgress = false;
+      this.waitingForIceRestartOffer = false;
+      this.stopIceRestartRequestRetry();
       this.publicEventEmitter.emit(AnamEvent.CONNECTION_ESTABLISHED);
       // Start collecting stats every 5 seconds
       this.startStatsCollection();
+    } else if (
+      this.peerConnection?.iceConnectionState === 'disconnected' ||
+      this.peerConnection?.iceConnectionState === 'failed'
+    ) {
+      this.logIceRestartState('ICE connection state requires restart');
+      void this.requestIceRestart();
+    }
+  }
+
+  private async requestIceRestart() {
+    if (
+      !this.peerConnection ||
+      !this.hasEstablishedConnection ||
+      this.iceRestartInProgress
+    ) {
+      this.logIceRestartState('Skipping ICE restart request', {
+        hasPeerConnection: Boolean(this.peerConnection),
+        hasEstablishedConnection: this.hasEstablishedConnection,
+        iceRestartInProgress: this.iceRestartInProgress,
+      });
+      return;
+    }
+
+    this.logIceRestartState('Requesting ICE restart');
+    this.iceRestartInProgress = true;
+    this.waitingForIceRestartOffer = true;
+    this.signallingClient.reconnect();
+    this.signallingClient.sendIceRestartRequest();
+    this.startIceRestartRequestRetry();
+  }
+
+  private startIceRestartRequestRetry() {
+    if (this.iceRestartRequestRetryInterval) {
+      return;
+    }
+
+    this.iceRestartRequestRetryInterval = setInterval(() => {
+      if (!this.waitingForIceRestartOffer || !this.hasEstablishedConnection) {
+        this.stopIceRestartRequestRetry();
+        return;
+      }
+      this.logIceRestartState('Retrying ICE restart request');
+      this.signallingClient.sendIceRestartRequest();
+    }, ICE_RESTART_REQUEST_RETRY_INTERVAL_MS);
+  }
+
+  private stopIceRestartRequestRetry() {
+    if (this.iceRestartRequestRetryInterval) {
+      clearInterval(this.iceRestartRequestRetryInterval);
+      this.iceRestartRequestRetryInterval = null;
     }
   }
 
   private onConnectionStateChange() {
-    if (this.peerConnection?.connectionState === 'closed') {
+    if (
+      this.peerConnection?.connectionState === 'connected' &&
+      this.hasEstablishedConnection === false
+    ) {
+      this.hasEstablishedConnection = true;
+    } else if (
+      this.peerConnection?.connectionState === 'disconnected' ||
+      this.peerConnection?.connectionState === 'failed'
+    ) {
+      this.logIceRestartState('Peer connection state requires restart');
+      void this.requestIceRestart();
+    } else if (this.peerConnection?.connectionState === 'closed') {
       console.error(
         'StreamingClient - onConnectionStateChange: Connection closed',
       );
@@ -640,6 +749,22 @@ export class StreamingClient {
         'The connection to our servers was lost. Please try again.',
       );
     }
+  }
+
+  private logIceRestartState(
+    message: string,
+    details?: Record<string, unknown>,
+  ) {
+    console.info('StreamingClient - ICE restart: ' + message, {
+      sessionId: this.sessionId,
+      iceConnectionState: this.peerConnection?.iceConnectionState,
+      connectionState: this.peerConnection?.connectionState,
+      signalingState: this.peerConnection?.signalingState,
+      hasEstablishedConnection: this.hasEstablishedConnection,
+      iceRestartInProgress: this.iceRestartInProgress,
+      waitingForIceRestartOffer: this.waitingForIceRestartOffer,
+      ...details,
+    });
   }
 
   private handleWebrtcFailure(err: any) {
@@ -1002,6 +1127,12 @@ export class StreamingClient {
       this.successMetricPoller = null;
     }
     this.successMetricFired = false;
+    this.connectionReceivedAnswer = false;
+    this.hasEstablishedConnection = false;
+    this.iceRestartInProgress = false;
+    this.waitingForIceRestartOffer = false;
+    this.stopIceRestartRequestRetry();
+    this.remoteIceCandidateBuffer = [];
 
     // stop the input audio stream
     try {

--- a/src/types/coreApi/StartSessionResponse.ts
+++ b/src/types/coreApi/StartSessionResponse.ts
@@ -7,7 +7,8 @@ export interface StartSessionResponse {
 }
 
 export interface ClientConfigResponse {
-  heartbeatIntervalSeconds: number;
-  maxWsReconnectionAttempts: number;
+  heartbeatIntervalSeconds?: number;
+  maxWsReconnectionAttempts?: number;
+  maxWsReconnectAttempts?: number;
   iceServers: RTCIceServer[];
 }

--- a/src/types/signalling/SignalMessage.ts
+++ b/src/types/signalling/SignalMessage.ts
@@ -2,6 +2,7 @@ export enum SignalMessageAction {
   OFFER = 'offer',
   ANSWER = 'answer',
   ICE_CANDIDATE = 'icecandidate',
+  ICE_RESTART_REQUEST = 'icerestartrequest',
   END_SESSION = 'endsession',
   HEARTBEAT = 'heartbeat',
   WARNING = 'warning',

--- a/src/types/signalling/SignallingClientOptions.ts
+++ b/src/types/signalling/SignallingClientOptions.ts
@@ -8,5 +8,6 @@ export interface SignallingURLOptions {
 export interface SignallingClientOptions {
   heartbeatIntervalSeconds?: number;
   maxWsReconnectionAttempts?: number;
+  maxWsReconnectAttempts?: number;
   url: SignallingURLOptions;
 }


### PR DESCRIPTION
## Summary

- Add SDK signaling support for `icerestartrequest` and restart `answer` messages.
- Request ICE restart automatically after an established WebRTC session enters ICE or peer disconnected/failed states.
- Force signaling websocket reconnect and retry restart requests during the server recovery window.
- Handle server restart offers without replacing the active session, tracks, data channel, or message history.
- Normalize `maxWsReconnectAttempts` / `maxWsReconnectionAttempts` aliases.

## Linear

- https://linear.app/anam-ai/issue/ENG-1118/implement-ice-restart-for-active-network-recovery-wifi-cellular

## Test Plan

- [x] `npm run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic ICE restart recovery to keep active WebRTC sessions alive during network switches and brief server restarts. Supports Linear ENG-1118 by negotiating restarts without replacing the session, tracks, or data channel.

- **New Features**
  - Auto-request ICE restart when ICE/peer state is disconnected/failed after initial connect.
  - New signalling: send `icerestartrequest`; handle server restart `offer` and send `answer`.
  - Force signalling WS reconnect and retry restart requests within a 15s recovery window (capped delay), with buffered message flush.
  - Buffer/flush remote ICE candidates around restart and add detailed state logs.
  - Accept both `maxWsReconnectionAttempts` and `maxWsReconnectAttempts` in config.

- **Migration**
  - No action needed; existing configs continue to work. `maxWsReconnectAttempts` is now also supported.

<sup>Written for commit 26c8c1f6dffe42def378a6d7c72474b12f18985c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

