### PR TITLE
feat: apply server iceTransportPolicy from clientConfig (caller config wins)

### DIFF
--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -232,6 +232,7 @@ export default class AnamClient {
       heartbeatIntervalSeconds,
       maxWsReconnectionAttempts,
       iceServers: defaultIceServers,
+      iceTransportPolicy,
     } = clientConfig;
 
     this.sessionId = sessionId;
@@ -264,6 +265,7 @@ export default class AnamClient {
             },
           },
           iceServers,
+          iceTransportPolicy,
           rtcConfiguration: this.clientOptions?.rtcConfiguration,
           inputAudio: {
             inputAudioState: this.inputAudioState,

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -46,6 +46,7 @@ export class StreamingClient {
   private signallingClient: SignallingClient;
   private engineApiRestClient: EngineApiRestClient;
   private iceServers: RTCIceServer[];
+  private iceTransportPolicy: RTCIceTransportPolicy | undefined;
   private rtcConfiguration: RTCConfiguration | undefined;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private peerConnection: RTCPeerConnection | null = null;
@@ -121,6 +122,7 @@ export class StreamingClient {
     );
     // set ice servers
     this.iceServers = options.iceServers;
+    this.iceTransportPolicy = options.iceTransportPolicy;
     this.rtcConfiguration = options.rtcConfiguration;
     // initialize signalling client
     this.signallingClient = new SignallingClient(
@@ -489,6 +491,10 @@ export class StreamingClient {
       iceCandidatePoolSize: ICE_CANDIDATE_POOL_SIZE,
       // caller's full RTCConfiguration passthrough (e.g. iceTransportPolicy: 'relay')
       ...this.rtcConfiguration,
+      iceTransportPolicy:
+        this.rtcConfiguration?.iceTransportPolicy ??
+        this.iceTransportPolicy ??
+        undefined,
       // resolved iceServers always wins for its field (preserves backward compat)
       iceServers: this.iceServers,
     });

--- a/src/types/coreApi/StartSessionResponse.ts
+++ b/src/types/coreApi/StartSessionResponse.ts
@@ -10,4 +10,5 @@ export interface ClientConfigResponse {
   heartbeatIntervalSeconds: number;
   maxWsReconnectionAttempts: number;
   iceServers: RTCIceServer[];
+  iceTransportPolicy?: RTCIceTransportPolicy;
 }

--- a/src/types/streaming/StreamingClientOptions.ts
+++ b/src/types/streaming/StreamingClientOptions.ts
@@ -7,6 +7,7 @@ export interface StreamingClientOptions {
   engine: EngineApiRestClientOptions;
   signalling: SignallingClientOptions;
   iceServers: RTCIceServer[];
+  iceTransportPolicy?: RTCIceTransportPolicy;
   rtcConfiguration?: RTCConfiguration;
   inputAudio: InputAudioOptions;
   apiGateway?: ApiGatewayConfig;


### PR DESCRIPTION
## Apply server-provided `iceTransportPolicy` from `clientConfig`

The start-session `clientConfig` may now include an optional `iceTransportPolicy` (alongside `iceServers`). This SDK change applies it when constructing the `RTCPeerConnection`, with **caller configuration taking precedence**.

### Behavior
Per-field precedence for `iceTransportPolicy`: `rtcConfiguration.iceTransportPolicy` (caller) → `clientConfig.iceTransportPolicy` (server) → unset (browser default). The existing `iceServers` precedence is unchanged (a caller-provided `iceServers`/`rtcConfiguration` still wins). An integrator who sets their own ICE config keeps full control.

### Notes
- Additive + backward-compatible: a server that omits `iceTransportPolicy` → unset; a caller-set value always wins.
- Minimal change (types + `AnamClient` passthrough + one line in `initPeerConnection`); `tsc` (both configs) and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply server-provided `iceTransportPolicy` from start-session `clientConfig` when creating the `RTCPeerConnection`, while keeping caller overrides first. This lets the server set defaults like `'relay'` without breaking existing caller configs.

- **New Features**
  - Respect `clientConfig.iceTransportPolicy` when building the peer connection; precedence: caller `rtcConfiguration.iceTransportPolicy` → server `clientConfig.iceTransportPolicy` → browser default. `iceServers` precedence unchanged.
  - Add optional `iceTransportPolicy` to `StartSessionResponse` and `StreamingClientOptions`, and plumb it through `AnamClient` and `StreamingClient`.

<sup>Written for commit 762e39ffaaf4302a4c4f48b56f8785ee2d7b970f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

