### PR TITLE
ENG-2332: Add granular WebRTC connection milestones

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format": "prettier --write \"{src,test}/**/*.ts\"",
     "lint": "eslint \"{src,test}/**/*.ts\" --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "test:connection-milestones": "npm run build:main && node test/connectionMilestonesHarness.js",
     "watch": "nodemon -e ts --watch src --exec \"npm run build\"",
     "prepare": "husky"
   },

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -11,6 +11,7 @@ import {
   setMetricsContext,
 } from './lib/ClientMetrics';
 import { generateCorrelationId } from './lib/correlationId';
+import { ClientConnectionMilestoneRecorder } from './lib/ConnectionMilestones';
 import { validateApiGatewayConfig } from './lib/validateApiGatewayConfig';
 import {
   CoreApiRestClient,
@@ -209,18 +210,58 @@ export default class AnamClient {
     return sessionOptions;
   }
 
+  private startConnectionAttempt(): ClientConnectionMilestoneRecorder {
+    const attemptCorrelationId = generateCorrelationId();
+    setMetricsContext({
+      attemptCorrelationId,
+      sessionId: null,
+      organizationId: this.organizationId,
+    });
+
+    const connectionMilestones = new ClientConnectionMilestoneRecorder({
+      context: {
+        attemptCorrelationId,
+        sessionId: null,
+        organizationId: this.organizationId,
+      },
+      connectionMilestoneSampleRatio:
+        this.clientOptions?.metrics?.connectionMilestoneSampleRatio,
+      slowConnectionThresholdMs:
+        this.clientOptions?.metrics?.slowConnectionThresholdMs,
+    });
+
+    sendClientMetric(
+      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT,
+      '1',
+    );
+
+    return connectionMilestones;
+  }
+
   private async startSession(
     userProvidedAudioStream?: MediaStream,
+    connectionMilestones?: ClientConnectionMilestoneRecorder,
   ): Promise<string> {
     const config = this.personaConfig;
     // build session options from client options
     const sessionOptions: StartSessionOptions | undefined =
       this.buildStartSessionOptionsForClient();
     // start a new session
-    const response: StartSessionResponse = await this.apiClient.startSession(
-      config,
-      sessionOptions,
-    );
+    connectionMilestones?.record('start_session_request_started');
+    let response: StartSessionResponse;
+    try {
+      response = await this.apiClient.startSession(config, sessionOptions);
+      connectionMilestones?.record('start_session_request_completed');
+    } catch (error) {
+      connectionMilestones?.record('start_session_request_failed', {
+        ...getErrorMilestoneTags(error),
+      });
+      connectionMilestones?.publishFailure({
+        failureStage: 'start_session_request',
+        ...getErrorMilestoneTags(error),
+      });
+      throw error;
+    }
     const {
       sessionId,
       clientConfig,
@@ -239,6 +280,10 @@ export default class AnamClient {
     this.toolCallManager.setActiveSession(sessionId);
     setMetricsContext({
       sessionId: this.sessionId,
+    });
+    connectionMilestones?.updateContext({
+      sessionId: this.sessionId,
+      organizationId: this.organizationId,
     });
 
     // Use custom ICE servers if provided, otherwise use server-provided ICE servers.
@@ -288,8 +333,13 @@ export default class AnamClient {
         this.publicEventEmitter,
         this.internalEventEmitter,
         this.toolCallManager,
+        connectionMilestones,
       );
     } catch (error) {
+      connectionMilestones?.publishFailure({
+        failureStage: 'streaming_client_initialization',
+        ...getErrorMilestoneTags(error),
+      });
       this.toolCallManager.clearSessionState();
       setMetricsContext({
         sessionId: null,
@@ -308,11 +358,17 @@ export default class AnamClient {
     return sessionId;
   }
 
-  private async startSessionIfNeeded(userProvidedAudioStream?: MediaStream) {
+  private async startSessionIfNeeded(
+    userProvidedAudioStream?: MediaStream,
+    connectionMilestones?: ClientConnectionMilestoneRecorder,
+  ) {
     if (!this.sessionId || !this.streamingClient) {
-      await this.startSession(userProvidedAudioStream);
+      await this.startSession(userProvidedAudioStream, connectionMilestones);
 
       if (!this.sessionId || !this.streamingClient) {
+        connectionMilestones?.publishFailure({
+          failureStage: 'start_session_validation',
+        });
         throw new ClientError(
           'Session ID or streaming client is not available after starting session',
           ErrorCode.CLIENT_ERROR_CODE_SERVER_ERROR,
@@ -331,22 +387,24 @@ export default class AnamClient {
     if (this._isStreaming) {
       throw new Error('Already streaming');
     }
-    // generate a new ID here to track the attempt
-    const attemptCorrelationId = generateCorrelationId();
-    setMetricsContext({
-      attemptCorrelationId,
-      sessionId: null, // reset sessionId
-    });
-    sendClientMetric(
-      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT,
-      '1',
-    );
+    const connectionMilestones = this.startConnectionAttempt();
     if (this.clientOptions?.disableInputAudio && userProvidedAudioStream) {
       console.warn(
         'AnamClient: Input audio is disabled. User-provided audio stream will be ignored.',
       );
     }
-    await this.startSessionIfNeeded(userProvidedAudioStream);
+    try {
+      await this.startSessionIfNeeded(
+        userProvidedAudioStream,
+        connectionMilestones,
+      );
+    } catch (error) {
+      connectionMilestones.publishFailure({
+        failureStage: 'start_session',
+        ...getErrorMilestoneTags(error),
+      });
+      throw error;
+    }
 
     this._isStreaming = true;
     return new Promise<MediaStream[]>((resolve) => {
@@ -397,24 +455,22 @@ export default class AnamClient {
     videoElementId: string,
     userProvidedAudioStream?: MediaStream,
   ): Promise<void> {
-    // generate a new ID here to track the attempt
-    const attemptCorrelationId = generateCorrelationId();
-    setMetricsContext({
-      attemptCorrelationId,
-      sessionId: null, // reset sessionId
-    });
-    sendClientMetric(
-      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT,
-      '1',
-    );
+    const connectionMilestones = this.startConnectionAttempt();
     if (this.clientOptions?.disableInputAudio && userProvidedAudioStream) {
       console.warn(
         'AnamClient: Input audio is disabled. User-provided audio stream will be ignored.',
       );
     }
     try {
-      await this.startSessionIfNeeded(userProvidedAudioStream);
+      await this.startSessionIfNeeded(
+        userProvidedAudioStream,
+        connectionMilestones,
+      );
     } catch (error) {
+      connectionMilestones.publishFailure({
+        failureStage: 'start_session',
+        ...getErrorMilestoneTags(error),
+      });
       if (error instanceof ClientError) {
         throw error;
       }
@@ -431,15 +487,29 @@ export default class AnamClient {
     }
 
     if (this._isStreaming) {
+      connectionMilestones.publishFailure({
+        failureStage: 'already_streaming',
+      });
       throw new Error('Already streaming');
     }
     this._isStreaming = true;
     if (!this.streamingClient) {
+      connectionMilestones.publishFailure({
+        failureStage: 'streaming_client_missing',
+      });
       throw new Error('Failed to stream: streaming client is not available');
     }
 
-    this.streamingClient.setMediaStreamTargetById(videoElementId);
-    this.streamingClient.startConnection();
+    try {
+      this.streamingClient.setMediaStreamTargetById(videoElementId);
+      this.streamingClient.startConnection();
+    } catch (error) {
+      connectionMilestones.publishFailure({
+        failureStage: 'start_connection',
+        ...getErrorMilestoneTags(error),
+      });
+      throw error;
+    }
   }
 
   /**
@@ -704,3 +774,19 @@ export default class AnamClient {
     return this.toolCallManager.registerHandler(toolName, handler);
   }
 }
+
+const getErrorMilestoneTags = (
+  error: unknown,
+): Record<string, string | number> => {
+  if (error instanceof ClientError) {
+    return {
+      errorName: error.name,
+      errorCode: error.code,
+      httpStatusCode: error.statusCode,
+    };
+  }
+  if (error instanceof Error) {
+    return { errorName: error.name };
+  }
+  return {};
+};

--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -68,14 +68,24 @@ export const sendClientMetric = async (
       ...tags,
     };
 
-    // Add session and organization IDs if available
-    if (anamMetricsContext.sessionId) {
+    // Fill session/organization/attempt IDs from the global context, but only
+    // when the caller did not already supply them. Callers that pass their own
+    // context (e.g. the connection-milestones recorder, which pins each metric
+    // to the attempt it belongs to) are authoritative; the global singleton is
+    // mutated by every new attempt and must not overwrite a caller's snapshot.
+    if (anamMetricsContext.sessionId && metricTags.sessionId === undefined) {
       metricTags.sessionId = anamMetricsContext.sessionId;
     }
-    if (anamMetricsContext.organizationId) {
+    if (
+      anamMetricsContext.organizationId &&
+      metricTags.organizationId === undefined
+    ) {
       metricTags.organizationId = anamMetricsContext.organizationId;
     }
-    if (anamMetricsContext.attemptCorrelationId) {
+    if (
+      anamMetricsContext.attemptCorrelationId &&
+      metricTags.attemptCorrelationId === undefined
+    ) {
       metricTags.attemptCorrelationId = anamMetricsContext.attemptCorrelationId;
     }
 

--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -8,6 +8,7 @@ export enum ClientMetricMeasurement {
   CLIENT_METRIC_MEASUREMENT_ERROR = 'client_error',
   CLIENT_METRIC_MEASUREMENT_CONNECTION_CLOSED = 'client_connection_closed',
   CLIENT_METRIC_MEASUREMENT_CONNECTION_ESTABLISHED = 'client_connection_established',
+  CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES = 'client_connection_milestones',
   CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT = 'client_session_attempt',
   CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS = 'client_session_success',
 }

--- a/src/lib/ConnectionMilestones.ts
+++ b/src/lib/ConnectionMilestones.ts
@@ -92,6 +92,24 @@ export class ClientConnectionMilestoneRecorder {
     this.sessionSuccessful = true;
     this.record('client_session_success', tags);
     this.publishIfNeeded();
+    // Once the success/publish decision has been made the recorder is done.
+    // Stop accumulating and release the buffer for the rest of the
+    // (potentially long-lived) session. Without this, a fast unsampled success
+    // — the default path, since connectionMilestoneSampleRatio defaults to 0 —
+    // never sets `published`, so the long-lived ICE/websocket event handlers
+    // keep appending to `milestones` for the entire call.
+    this.finalize();
+  }
+
+  /**
+   * Make the recorder inert and release its buffer. `published` gates
+   * record()/publish()/publishFailure(), so flipping it here stops all further
+   * recording and publishing. publish() (if it ran) already serialized the
+   * milestones synchronously, so clearing the buffer afterwards is safe.
+   */
+  private finalize() {
+    this.published = true;
+    this.milestones.length = 0;
   }
 
   public publishFailure(tags?: ConnectionMilestoneTags) {

--- a/src/lib/ConnectionMilestones.ts
+++ b/src/lib/ConnectionMilestones.ts
@@ -1,0 +1,202 @@
+import {
+  AnamMetricsContext,
+  ClientMetricMeasurement,
+  sendClientMetric,
+} from './ClientMetrics';
+import { ConnectionMilestoneMetricsOptions } from '../types/ConnectionMilestoneMetricsOptions';
+
+export const DEFAULT_CONNECTION_MILESTONE_SAMPLE_RATIO = 0;
+export const DEFAULT_SLOW_CONNECTION_THRESHOLD_MS = 5000;
+
+type ConnectionMilestonePublishReason = 'sampled' | 'slow' | 'failed';
+type ConnectionMilestoneTagValue = string | number | boolean;
+type ConnectionMilestoneTags = Record<
+  string,
+  ConnectionMilestoneTagValue | null | undefined
+>;
+
+interface ClientConnectionMilestone {
+  name: string;
+  elapsedMs: number;
+  tags?: Record<string, ConnectionMilestoneTagValue>;
+}
+
+interface ClientConnectionMilestoneRecorderOptions
+  extends ConnectionMilestoneMetricsOptions {
+  context?: Partial<AnamMetricsContext>;
+  now?: () => number;
+  random?: () => number;
+}
+
+export class ClientConnectionMilestoneRecorder {
+  private readonly now: () => number;
+  private readonly attemptStartedAtMs: number;
+  private readonly sampleRatio: number;
+  private readonly slowConnectionThresholdMs: number;
+  private readonly sampled: boolean;
+  private readonly milestones: ClientConnectionMilestone[] = [];
+
+  private context: AnamMetricsContext = {
+    sessionId: null,
+    organizationId: null,
+    attemptCorrelationId: null,
+  };
+  private published = false;
+  private sessionSuccessful = false;
+
+  constructor(options: ClientConnectionMilestoneRecorderOptions = {}) {
+    this.now = options.now ?? getMonotonicNow;
+    this.attemptStartedAtMs = this.now();
+    this.sampleRatio = clampRatio(
+      options.connectionMilestoneSampleRatio ??
+        DEFAULT_CONNECTION_MILESTONE_SAMPLE_RATIO,
+    );
+    this.slowConnectionThresholdMs = Math.max(
+      0,
+      finiteNumberOrDefault(
+        options.slowConnectionThresholdMs,
+        DEFAULT_SLOW_CONNECTION_THRESHOLD_MS,
+      ),
+    );
+    this.sampled = (options.random ?? Math.random)() < this.sampleRatio;
+
+    this.updateContext(options.context ?? {});
+    this.record('client_session_attempt');
+  }
+
+  public updateContext(context: Partial<AnamMetricsContext>) {
+    this.context = { ...this.context, ...context };
+  }
+
+  public record(name: string, tags?: ConnectionMilestoneTags) {
+    if (this.published) {
+      return;
+    }
+
+    const sanitizedTags = sanitizeMilestoneTags(tags);
+    const milestone: ClientConnectionMilestone = {
+      name,
+      elapsedMs: this.elapsedMs(),
+    };
+    if (Object.keys(sanitizedTags).length > 0) {
+      milestone.tags = sanitizedTags;
+    }
+    this.milestones.push(milestone);
+  }
+
+  public recordSessionSuccess(tags?: ConnectionMilestoneTags) {
+    if (this.sessionSuccessful) {
+      return;
+    }
+
+    this.sessionSuccessful = true;
+    this.record('client_session_success', tags);
+    this.publishIfNeeded();
+  }
+
+  public publishFailure(tags?: ConnectionMilestoneTags) {
+    if (this.sessionSuccessful || this.published) {
+      return;
+    }
+
+    this.record('connection_attempt_failed', tags);
+    this.publish('failed', tags);
+  }
+
+  public publishIfNeeded() {
+    if (this.published) {
+      return;
+    }
+
+    if (this.elapsedMs() >= this.slowConnectionThresholdMs) {
+      this.publish('slow');
+      return;
+    }
+
+    if (this.sampled) {
+      this.publish('sampled');
+    }
+  }
+
+  private publish(
+    reason: ConnectionMilestonePublishReason,
+    tags?: ConnectionMilestoneTags,
+  ) {
+    if (this.published || this.milestones.length === 0) {
+      return;
+    }
+
+    this.published = true;
+    const serializedMilestones = JSON.stringify(this.milestones);
+    const metricTags = sanitizeMetricTags({
+      ...tags,
+      ...this.context,
+      publishReason: reason,
+      attemptDurationMs: this.elapsedMs(),
+      milestoneCount: this.milestones.length,
+      connectionMilestoneSampleRatio: this.sampleRatio,
+      slowConnectionThresholdMs: this.slowConnectionThresholdMs,
+      wasSampled: this.sampled ? 1 : 0,
+      milestones: serializedMilestones,
+    });
+
+    void sendClientMetric(
+      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES,
+      '1',
+      metricTags,
+    );
+  }
+
+  private elapsedMs(): number {
+    return Math.max(0, Math.round(this.now() - this.attemptStartedAtMs));
+  }
+}
+
+const getMonotonicNow = () => {
+  if (typeof performance !== 'undefined') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const clampRatio = (value: number): number => {
+  const finiteValue = finiteNumberOrDefault(
+    value,
+    DEFAULT_CONNECTION_MILESTONE_SAMPLE_RATIO,
+  );
+  return Math.min(1, Math.max(0, finiteValue));
+};
+
+const finiteNumberOrDefault = (value: unknown, fallback: number): number => {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+};
+
+const sanitizeMilestoneTags = (
+  tags?: ConnectionMilestoneTags,
+): Record<string, ConnectionMilestoneTagValue> => {
+  if (!tags) {
+    return {};
+  }
+
+  const sanitizedTags: Record<string, ConnectionMilestoneTagValue> = {};
+  Object.entries(tags).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      return;
+    }
+    sanitizedTags[key] = value;
+  });
+  return sanitizedTags;
+};
+
+const sanitizeMetricTags = (
+  tags: ConnectionMilestoneTags,
+): Record<string, string | number> => {
+  const metricTags: Record<string, string | number> = {};
+  Object.entries(sanitizeMilestoneTags(tags)).forEach(([key, value]) => {
+    metricTags[key] = typeof value === 'boolean' ? String(value) : value;
+  });
+  return metricTags;
+};

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -1,4 +1,5 @@
 import { InternalEventEmitter, PublicEventEmitter } from '.';
+import { ClientConnectionMilestoneRecorder } from '../lib/ConnectionMilestones';
 import {
   AnamEvent,
   InternalEvent,
@@ -27,6 +28,7 @@ export class SignallingClient {
   private socket: WebSocket | null = null;
   private heartBeatIntervalRef: ReturnType<typeof setInterval> | null = null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
+  private connectionMilestones: ClientConnectionMilestoneRecorder | undefined;
 
   constructor(
     sessionId: string,
@@ -34,10 +36,12 @@ export class SignallingClient {
     publicEventEmitter: PublicEventEmitter,
     internalEventEmitter: InternalEventEmitter,
     apiGatewayConfig?: ApiGatewayConfig,
+    connectionMilestones?: ClientConnectionMilestoneRecorder,
   ) {
     this.publicEventEmitter = publicEventEmitter;
     this.internalEventEmitter = internalEventEmitter;
     this.apiGatewayConfig = apiGatewayConfig;
+    this.connectionMilestones = connectionMilestones;
 
     if (!sessionId) {
       throw new Error('Signalling Client: sessionId is required');
@@ -105,6 +109,9 @@ export class SignallingClient {
   }
 
   public connect(): WebSocket {
+    this.connectionMilestones?.record('websocket_connecting', {
+      attemptNumber: this.wsConnectionAttempts + 1,
+    });
     this.socket = new WebSocket(this.url.href);
     this.socket.onopen = this.onOpen.bind(this);
     this.socket.onclose = this.onClose.bind(this);
@@ -192,6 +199,9 @@ export class SignallingClient {
       throw new Error('SignallingClient - onOpen: socket is null');
     }
     try {
+      this.connectionMilestones?.record('websocket_open', {
+        attemptNumber: this.wsConnectionAttempts + 1,
+      });
       this.wsConnectionAttempts = 0;
       this.flushSendingBuffer();
       this.socket.onmessage = this.onMessage.bind(this);
@@ -206,21 +216,35 @@ export class SignallingClient {
     }
   }
 
-  private async onClose() {
+  private async onClose(event?: CloseEvent) {
+    this.connectionMilestones?.record('websocket_closed', {
+      attemptNumber: this.wsConnectionAttempts + 1,
+      closeCode: event?.code,
+      wasClean: event?.wasClean,
+    });
     this.wsConnectionAttempts += 1;
     if (this.stopSignal) {
       return;
     }
     if (this.wsConnectionAttempts <= this.maxWsReconnectionAttempts) {
+      const retryDelayMs = 100 * this.wsConnectionAttempts;
+      this.connectionMilestones?.record('websocket_retry_scheduled', {
+        attemptNumber: this.wsConnectionAttempts + 1,
+        delayMs: retryDelayMs,
+      });
       this.socket = null;
       setTimeout(() => {
         this.connect();
-      }, 100 * this.wsConnectionAttempts);
+      }, retryDelayMs);
     } else {
       if (this.heartBeatIntervalRef) {
         clearInterval(this.heartBeatIntervalRef);
         this.heartBeatIntervalRef = null;
       }
+      this.connectionMilestones?.publishFailure({
+        failureStage: 'websocket',
+        closeCode: event?.code,
+      });
       this.publicEventEmitter.emit(
         AnamEvent.CONNECTION_CLOSED,
         ConnectionClosedCode.SIGNALLING_CLIENT_CONNECTION_FAILURE,
@@ -232,6 +256,9 @@ export class SignallingClient {
     if (this.stopSignal) {
       return;
     }
+    this.connectionMilestones?.record('websocket_error', {
+      eventType: event.type,
+    });
     console.error('SignallingClient - onError: ', event);
   }
 

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -614,8 +614,7 @@ export class StreamingClient {
           );
         }
         if (this.connectionReceivedAnswer) {
-          await this.peerConnection.addIceCandidate(candidate);
-          this.recordFirstRemoteIceCandidateApplied(candidate);
+          await this.addRemoteIceCandidate(candidate);
         } else {
           this.remoteIceCandidateBuffer.push(candidate);
         }
@@ -679,8 +678,30 @@ export class StreamingClient {
     const bufferedCandidates = [...this.remoteIceCandidateBuffer];
     this.remoteIceCandidateBuffer = [];
     for (const candidate of bufferedCandidates) {
-      await this.peerConnection?.addIceCandidate(candidate);
+      await this.addRemoteIceCandidate(candidate);
+    }
+  }
+
+  /**
+   * Add a single remote ICE candidate to the peer connection.
+   * Each candidate is added independently: a rejection on one candidate is
+   * logged and swallowed so it cannot abort the flush loop (dropping the
+   * remaining buffered candidates) or surface as an unhandled rejection from
+   * the ANSWER handler. The "first applied" milestone is only recorded after a
+   * genuine, successful add.
+   */
+  private async addRemoteIceCandidate(candidate: RTCIceCandidate) {
+    if (!this.peerConnection) {
+      return;
+    }
+    try {
+      await this.peerConnection.addIceCandidate(candidate);
       this.recordFirstRemoteIceCandidateApplied(candidate);
+    } catch (error) {
+      console.warn(
+        'StreamingClient - addRemoteIceCandidate: failed to add remote ICE candidate',
+        error,
+      );
     }
   }
 

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -465,6 +465,7 @@ export class StreamingClient {
         );
         return;
       }
+      this.resetAttemptScopedMilestoneState();
       this.connectionMilestones?.record('connection_start_requested');
       // start the connection
       this.signallingClient.connect();
@@ -472,6 +473,13 @@ export class StreamingClient {
       console.error('StreamingClient - startConnection: error', error);
       this.handleWebrtcFailure(error);
     }
+  }
+
+  private resetAttemptScopedMilestoneState() {
+    this.firstLocalIceCandidateSent = false;
+    this.firstRemoteIceCandidateReceived = false;
+    this.firstRemoteIceCandidateApplied = false;
+    this.connectionEstablishedMilestoneRecorded = false;
   }
 
   public async stopConnection() {

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -3,6 +3,7 @@ import {
   createRTCStatsReport,
   sendClientMetric,
 } from '../lib/ClientMetrics';
+import { ClientConnectionMilestoneRecorder } from '../lib/ConnectionMilestones';
 import {
   EngineApiRestClient,
   InternalEventEmitter,
@@ -70,6 +71,11 @@ export class StreamingClient {
   private statsCollectionInterval: ReturnType<typeof setInterval> | null = null;
   private agentAudioInputStream: AgentAudioInputStream | null = null;
   private toolCallManager: ToolCallManager;
+  private connectionMilestones: ClientConnectionMilestoneRecorder | undefined;
+  private firstLocalIceCandidateSent = false;
+  private firstRemoteIceCandidateReceived = false;
+  private firstRemoteIceCandidateApplied = false;
+  private connectionEstablishedMilestoneRecorded = false;
 
   constructor(
     sessionId: string,
@@ -77,10 +83,12 @@ export class StreamingClient {
     publicEventEmitter: PublicEventEmitter,
     internalEventEmitter: InternalEventEmitter,
     toolCallManager: ToolCallManager,
+    connectionMilestones?: ClientConnectionMilestoneRecorder,
   ) {
     this.publicEventEmitter = publicEventEmitter;
     this.internalEventEmitter = internalEventEmitter;
     this.toolCallManager = toolCallManager;
+    this.connectionMilestones = connectionMilestones;
     this.apiGatewayConfig = options.apiGateway;
     // initialize input audio state
     const { inputAudio } = options;
@@ -131,6 +139,7 @@ export class StreamingClient {
       this.publicEventEmitter,
       this.internalEventEmitter,
       this.apiGatewayConfig,
+      this.connectionMilestones,
     );
     // initialize engine API client
     this.engineApiRestClient = new EngineApiRestClient(
@@ -212,6 +221,23 @@ export class StreamingClient {
     });
   }
 
+  private recordSessionSuccess(detectionMethod: string) {
+    if (this.successMetricFired) {
+      return;
+    }
+
+    this.successMetricFired = true;
+    this.connectionMilestones?.record('first_video_frame', {
+      detectionMethod,
+    });
+    this.connectionMilestones?.recordSessionSuccess({ detectionMethod });
+    sendClientMetric(
+      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS,
+      '1',
+      { detectionMethod },
+    );
+  }
+
   private startSuccessMetricPolling() {
     if (this.successMetricPoller || this.successMetricFired) {
       return;
@@ -219,6 +245,13 @@ export class StreamingClient {
 
     const timeoutId = setTimeout(() => {
       if (this.successMetricPoller) {
+        this.connectionMilestones?.record('first_video_frame_timeout', {
+          timeoutMs: SUCCESS_METRIC_POLLING_TIMEOUT_MS,
+        });
+        this.connectionMilestones?.publishFailure({
+          failureStage: 'first_video_frame',
+          timeoutMs: SUCCESS_METRIC_POLLING_TIMEOUT_MS,
+        });
         console.warn(
           'No video frames received, there is a problem with the connection.',
         );
@@ -270,12 +303,7 @@ export class StreamingClient {
           }
         });
         if (videoDetected && !this.successMetricFired) {
-          this.successMetricFired = true;
-          sendClientMetric(
-            ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS,
-            '1',
-            detectionMethod ? { detectionMethod } : undefined,
-          );
+          this.recordSessionSuccess(detectionMethod ?? 'unknown');
           if (this.successMetricPoller) {
             clearInterval(this.successMetricPoller);
           }
@@ -437,6 +465,7 @@ export class StreamingClient {
         );
         return;
       }
+      this.connectionMilestones?.record('connection_start_requested');
       // start the connection
       this.signallingClient.connect();
     } catch (error) {
@@ -486,6 +515,7 @@ export class StreamingClient {
   }
 
   private async initPeerConnection() {
+    this.connectionMilestones?.record('peer_connection_creating');
     this.peerConnection = new RTCPeerConnection({
       // SDK default first (caller's rtcConfiguration may override it)
       iceCandidatePoolSize: ICE_CANDIDATE_POOL_SIZE,
@@ -497,6 +527,14 @@ export class StreamingClient {
         undefined,
       // resolved iceServers always wins for its field (preserves backward compat)
       iceServers: this.iceServers,
+    });
+    this.connectionMilestones?.record('peer_connection_created', {
+      iceCandidatePoolSize: ICE_CANDIDATE_POOL_SIZE,
+      iceServerCount: this.iceServers.length,
+      iceTransportPolicy:
+        this.rtcConfiguration?.iceTransportPolicy ??
+        this.iceTransportPolicy ??
+        'all',
     });
     // set event handlers
     this.peerConnection.onicecandidate = this.onIceCandidate.bind(this);
@@ -515,12 +553,18 @@ export class StreamingClient {
     // add transceivers
     this.peerConnection.addTransceiver('video', { direction: 'recvonly' });
     if (this.disableInputAudio) {
+      this.connectionMilestones?.record('microphone_permission_skipped', {
+        reason: 'input_audio_disabled',
+      });
       this.peerConnection.addTransceiver('audio', { direction: 'recvonly' });
     } else {
       this.peerConnection.addTransceiver('audio', { direction: 'sendrecv' });
 
       // Handle audio setup after transceivers are configured
       if (this.inputAudioStream) {
+        this.connectionMilestones?.record('input_audio_stream_provided', {
+          audioTrackCount: this.inputAudioStream.getAudioTracks().length,
+        });
         // User provided an audio stream, set it up immediately
         await this.setupAudioTrack();
       } else {
@@ -541,24 +585,39 @@ export class StreamingClient {
       return;
     }
     switch (signalMessage.actionType) {
-      case SignalMessageAction.ANSWER:
+      case SignalMessageAction.ANSWER: {
+        this.connectionMilestones?.record('answer_received');
         const answer = signalMessage.payload as RTCSessionDescriptionInit;
         await this.peerConnection.setRemoteDescription(answer);
+        this.connectionMilestones?.record('remote_description_set');
         this.connectionReceivedAnswer = true;
         // flush the remote buffer
-        this.flushRemoteIceCandidateBuffer();
+        await this.flushRemoteIceCandidateBuffer();
         break;
-      case SignalMessageAction.ICE_CANDIDATE:
+      }
+      case SignalMessageAction.ICE_CANDIDATE: {
         const iceCandidateConfig = signalMessage.payload as RTCIceCandidateInit;
         const candidate = new RTCIceCandidate(iceCandidateConfig);
+        if (!this.firstRemoteIceCandidateReceived) {
+          this.firstRemoteIceCandidateReceived = true;
+          this.connectionMilestones?.record(
+            'first_remote_ice_candidate_received',
+            getIceCandidateMilestoneTags(candidate),
+          );
+        }
         if (this.connectionReceivedAnswer) {
           await this.peerConnection.addIceCandidate(candidate);
+          this.recordFirstRemoteIceCandidateApplied(candidate);
         } else {
           this.remoteIceCandidateBuffer.push(candidate);
         }
         break;
+      }
       case SignalMessageAction.END_SESSION:
         const reason = signalMessage.payload as string;
+        this.connectionMilestones?.publishFailure({
+          failureStage: 'server_closed_connection',
+        });
         this.publicEventEmitter.emit(
           AnamEvent.CONNECTION_CLOSED,
           ConnectionClosedCode.SERVER_CLOSED_CONNECTION,
@@ -608,11 +667,24 @@ export class StreamingClient {
     }
   }
 
-  private flushRemoteIceCandidateBuffer() {
-    this.remoteIceCandidateBuffer.forEach((candidate) => {
-      this.peerConnection?.addIceCandidate(candidate);
-    });
+  private async flushRemoteIceCandidateBuffer() {
+    const bufferedCandidates = [...this.remoteIceCandidateBuffer];
     this.remoteIceCandidateBuffer = [];
+    for (const candidate of bufferedCandidates) {
+      await this.peerConnection?.addIceCandidate(candidate);
+      this.recordFirstRemoteIceCandidateApplied(candidate);
+    }
+  }
+
+  private recordFirstRemoteIceCandidateApplied(candidate: RTCIceCandidate) {
+    if (this.firstRemoteIceCandidateApplied) {
+      return;
+    }
+    this.firstRemoteIceCandidateApplied = true;
+    this.connectionMilestones?.record(
+      'first_remote_ice_candidate_applied',
+      getIceCandidateMilestoneTags(candidate),
+    );
   }
 
   /**
@@ -622,22 +694,60 @@ export class StreamingClient {
    */
   private onIceCandidate(event: RTCPeerConnectionIceEvent) {
     if (event.candidate) {
+      if (!this.firstLocalIceCandidateSent) {
+        this.firstLocalIceCandidateSent = true;
+        this.connectionMilestones?.record(
+          'first_local_ice_candidate_sent',
+          getIceCandidateMilestoneTags(event.candidate),
+        );
+      }
       this.signallingClient.sendIceCandidate(event.candidate);
+    } else {
+      this.connectionMilestones?.record('ice_gathering_complete');
     }
   }
 
   private onIceConnectionStateChange() {
+    const iceConnectionState = this.peerConnection?.iceConnectionState;
+    if (iceConnectionState) {
+      this.connectionMilestones?.record('ice_connection_state_changed', {
+        iceConnectionState,
+      });
+    }
     if (
       this.peerConnection?.iceConnectionState === 'connected' ||
       this.peerConnection?.iceConnectionState === 'completed'
     ) {
+      if (!this.connectionEstablishedMilestoneRecorded) {
+        this.connectionEstablishedMilestoneRecorded = true;
+        this.connectionMilestones?.record('client_connection_established', {
+          iceConnectionState: this.peerConnection.iceConnectionState,
+        });
+      }
       this.publicEventEmitter.emit(AnamEvent.CONNECTION_ESTABLISHED);
       // Start collecting stats every 5 seconds
       this.startStatsCollection();
+    } else if (this.peerConnection?.iceConnectionState === 'failed') {
+      this.connectionMilestones?.publishFailure({
+        failureStage: 'ice_connection',
+        iceConnectionState: this.peerConnection.iceConnectionState,
+      });
     }
   }
 
   private onConnectionStateChange() {
+    const connectionState = this.peerConnection?.connectionState;
+    if (connectionState) {
+      this.connectionMilestones?.record('webrtc_connection_state_changed', {
+        connectionState,
+      });
+    }
+    if (this.peerConnection?.connectionState === 'failed') {
+      this.connectionMilestones?.publishFailure({
+        failureStage: 'webrtc_connection',
+        connectionState: this.peerConnection.connectionState,
+      });
+    }
     if (this.peerConnection?.connectionState === 'closed') {
       console.error(
         'StreamingClient - onConnectionStateChange: Connection closed',
@@ -649,6 +759,11 @@ export class StreamingClient {
   }
 
   private handleWebrtcFailure(err: any) {
+    this.connectionMilestones?.record('webrtc_failure', getErrorTags(err));
+    this.connectionMilestones?.publishFailure({
+      failureStage: 'webrtc',
+      ...getErrorTags(err),
+    });
     console.error({ message: 'StreamingClient - handleWebrtcFailure: ', err });
     if (err.name === 'NotAllowedError' && err.message === 'Permission denied') {
       this.publicEventEmitter.emit(
@@ -674,6 +789,7 @@ export class StreamingClient {
 
   private onTrackEventHandler(event: RTCTrackEvent) {
     if (event.track.kind === 'video') {
+      this.connectionMilestones?.record('video_track_received');
       // start polling stats to detect successful video data received
       this.startSuccessMetricPolling();
 
@@ -688,17 +804,11 @@ export class StreamingClient {
           // unregister the callback after the first frame
           this.videoElement?.cancelVideoFrameCallback(handle);
           this.publicEventEmitter.emit(AnamEvent.VIDEO_PLAY_STARTED);
-          if (!this.successMetricFired) {
-            this.successMetricFired = true;
-            sendClientMetric(
-              ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS,
-              '1',
-              { detectionMethod: 'videoElement' },
-            );
-          }
+          this.recordSessionSuccess('videoElement');
         });
       }
     } else if (event.track.kind === 'audio') {
+      this.connectionMilestones?.record('audio_track_received');
       this.audioStream = event.streams[0];
       this.publicEventEmitter.emit(
         AnamEvent.AUDIO_STREAM_STARTED,
@@ -741,10 +851,14 @@ export class StreamingClient {
     const dataChannel = this.peerConnection.createDataChannel('session', {
       ordered: true,
     });
+    this.connectionMilestones?.record('data_channel_created');
     dataChannel.onopen = () => {
       this.dataChannel = dataChannel ?? null;
+      this.connectionMilestones?.record('data_channel_open');
     };
-    dataChannel.onclose = () => {};
+    dataChannel.onclose = () => {
+      this.connectionMilestones?.record('data_channel_closed');
+    };
     // pass text message to the message history client
     dataChannel.onmessage = (event) => {
       try {
@@ -859,6 +973,7 @@ export class StreamingClient {
       permissionState: AudioPermissionState.PENDING,
     };
 
+    this.connectionMilestones?.record('microphone_permission_pending');
     this.publicEventEmitter.emit(AnamEvent.MIC_PERMISSION_PENDING);
 
     try {
@@ -882,6 +997,7 @@ export class StreamingClient {
         permissionState: AudioPermissionState.GRANTED,
       };
 
+      this.connectionMilestones?.record('microphone_permission_granted');
       this.publicEventEmitter.emit(AnamEvent.MIC_PERMISSION_GRANTED);
 
       // Now add the audio track to the existing connection
@@ -893,6 +1009,9 @@ export class StreamingClient {
         permissionState: AudioPermissionState.DENIED,
       };
 
+      this.connectionMilestones?.record('microphone_permission_denied', {
+        ...getErrorTags(error),
+      });
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       this.publicEventEmitter.emit(
@@ -948,6 +1067,9 @@ export class StreamingClient {
     }
 
     // pass the stream to the callback
+    this.connectionMilestones?.record('input_audio_stream_started', {
+      audioTrackCount: this.inputAudioStream.getAudioTracks().length,
+    });
     this.publicEventEmitter.emit(
       AnamEvent.INPUT_AUDIO_STREAM_STARTED,
       this.inputAudioStream,
@@ -966,14 +1088,24 @@ export class StreamingClient {
 
     // create offer and set local description
     try {
+      this.connectionMilestones?.record('offer_creation_started');
       const offer: RTCSessionDescriptionInit =
         await this.peerConnection.createOffer();
+      this.connectionMilestones?.record('offer_creation_completed');
       await this.peerConnection.setLocalDescription(offer);
+      this.connectionMilestones?.record('local_description_set');
     } catch (error) {
       console.error(
         'StreamingClient - initPeerConnectionAndSendOffer: error creating offer',
         error,
       );
+      this.connectionMilestones?.record('offer_creation_failed', {
+        ...getErrorTags(error),
+      });
+      this.connectionMilestones?.publishFailure({
+        failureStage: 'offer_creation',
+        ...getErrorTags(error),
+      });
     }
 
     if (!this.peerConnection.localDescription) {
@@ -982,6 +1114,7 @@ export class StreamingClient {
       );
     }
     await this.signallingClient.sendOffer(this.peerConnection.localDescription);
+    this.connectionMilestones?.record('offer_sent');
   }
 
   private async shutdown() {
@@ -1052,3 +1185,56 @@ export class StreamingClient {
     }
   }
 }
+
+const getIceCandidateMilestoneTags = (
+  candidate: RTCIceCandidate,
+): Record<string, string | number> => {
+  const safeCandidate = candidate as RTCIceCandidate & {
+    type?: string;
+    protocol?: string;
+    relayProtocol?: string;
+    tcpType?: string;
+    component?: string;
+  };
+
+  return removeEmptyTags({
+    candidateType: safeCandidate.type,
+    protocol: safeCandidate.protocol,
+    relayProtocol: safeCandidate.relayProtocol,
+    tcpType: safeCandidate.tcpType,
+    component: safeCandidate.component,
+  });
+};
+
+const getErrorTags = (error: unknown): Record<string, string | number> => {
+  if (error instanceof Error) {
+    return removeEmptyTags({ errorName: error.name });
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const possibleError = error as { name?: unknown; code?: unknown };
+    return removeEmptyTags({
+      errorName:
+        typeof possibleError.name === 'string' ? possibleError.name : undefined,
+      errorCode:
+        typeof possibleError.code === 'string' ||
+        typeof possibleError.code === 'number'
+          ? possibleError.code
+          : undefined,
+    });
+  }
+
+  return {};
+};
+
+const removeEmptyTags = (
+  tags: Record<string, string | number | undefined>,
+): Record<string, string | number> => {
+  const sanitizedTags: Record<string, string | number> = {};
+  Object.entries(tags).forEach(([key, value]) => {
+    if (value !== undefined) {
+      sanitizedTags[key] = value;
+    }
+  });
+  return sanitizedTags;
+};

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -1,4 +1,5 @@
 import { ApiOptions } from '../types';
+import { ConnectionMilestoneMetricsOptions } from './ConnectionMilestoneMetricsOptions';
 import { VoiceDetectionOptions } from './VoiceDetectionOptions';
 
 export interface AnamPublicClientOptions {
@@ -6,7 +7,7 @@ export interface AnamPublicClientOptions {
   voiceDetection?: VoiceDetectionOptions;
   audioDeviceId?: string;
   disableInputAudio?: boolean;
-  metrics?: {
+  metrics?: ConnectionMilestoneMetricsOptions & {
     showPeerConnectionStatsReport?: boolean;
     peerConnectionStatsReportOutputFormat?: 'console' | 'json';
     /**

--- a/src/types/ConnectionMilestoneMetricsOptions.ts
+++ b/src/types/ConnectionMilestoneMetricsOptions.ts
@@ -1,0 +1,15 @@
+export interface ConnectionMilestoneMetricsOptions {
+  /**
+   * Ratio of successful normal connection attempts that should publish detailed
+   * connection milestones. Failed and slow attempts are published regardless.
+   * Values are clamped to the 0-1 range.
+   * @default 0
+   */
+  connectionMilestoneSampleRatio?: number;
+  /**
+   * Successful attempts with total connection setup time at or above this
+   * threshold publish detailed connection milestones even when not sampled.
+   * @default 5000
+   */
+  slowConnectionThresholdMs?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { AnamClientOptions } from './AnamClientOptions';
+export type { ConnectionMilestoneMetricsOptions } from './ConnectionMilestoneMetricsOptions';
 export type * from './signalling';
 export { SignalMessageAction } from './signalling'; // need to export this explicitly to avoid enum import issues
 export type * from './streaming';

--- a/test/connectionMilestonesHarness.js
+++ b/test/connectionMilestonesHarness.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+const {
+  ClientConnectionMilestoneRecorder,
+} = require('../dist/main/lib/ConnectionMilestones');
+
+const requests = [];
+global.fetch = async (_url, options) => {
+  requests.push(JSON.parse(options.body));
+  return { ok: true };
+};
+
+const resetRequests = () => {
+  requests.length = 0;
+};
+
+const createRecorder = ({
+  sampleRatio = 0,
+  slowThresholdMs = 5000,
+  randomValue = 1,
+  now,
+}) =>
+  new ClientConnectionMilestoneRecorder({
+    context: {
+      attemptCorrelationId: 'attempt-1',
+      organizationId: 'org-1',
+    },
+    connectionMilestoneSampleRatio: sampleRatio,
+    slowConnectionThresholdMs: slowThresholdMs,
+    random: () => randomValue,
+    now,
+  });
+
+const parseMilestones = (request) => JSON.parse(request.tags.milestones);
+
+async function runHarness() {
+  let nowMs = 0;
+  let recorder = createRecorder({ now: () => nowMs });
+  nowMs = 100;
+  recorder.recordSessionSuccess({ detectionMethod: 'harness' });
+  assert.equal(
+    requests.length,
+    0,
+    'normal unsampled success should not publish',
+  );
+
+  resetRequests();
+  nowMs = 0;
+  recorder = createRecorder({
+    sampleRatio: 1,
+    randomValue: 0.5,
+    now: () => nowMs,
+  });
+  nowMs = 100;
+  recorder.recordSessionSuccess({ detectionMethod: 'harness' });
+  assert.equal(requests.length, 1, 'sampled success should publish once');
+  assert.equal(requests[0].name, 'client_connection_milestones');
+  assert.equal(requests[0].tags.publishReason, 'sampled');
+  assert.deepEqual(
+    parseMilestones(requests[0]).map((milestone) => milestone.name),
+    ['client_session_attempt', 'client_session_success'],
+  );
+
+  resetRequests();
+  nowMs = 0;
+  recorder = createRecorder({
+    slowThresholdMs: 50,
+    now: () => nowMs,
+  });
+  nowMs = 75;
+  recorder.recordSessionSuccess({ detectionMethod: 'harness' });
+  assert.equal(requests.length, 1, 'slow success should publish once');
+  assert.equal(requests[0].tags.publishReason, 'slow');
+  assert.equal(requests[0].tags.attemptDurationMs, 75);
+
+  resetRequests();
+  nowMs = 0;
+  recorder = createRecorder({ now: () => nowMs });
+  nowMs = 25;
+  recorder.publishFailure({ failureStage: 'harness' });
+  assert.equal(requests.length, 1, 'failed attempt should publish once');
+  assert.equal(requests[0].tags.publishReason, 'failed');
+  assert.equal(requests[0].tags.failureStage, 'harness');
+}
+
+runHarness()
+  .then(() => {
+    console.log('connection milestone harness passed');
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add batched client_connection_milestones telemetry for sampled, slow, and failed WebRTC attempts
- record client-side start-session, websocket, peer connection, offer, ICE, data channel, mic, media, and first-frame milestones
- add metric options and deterministic sampling/slow-threshold harness

## Verification
- npm run build
- npm run test:connection-milestones