### PR TITLE
fix: harden WebRTC connection milestone telemetry (review fixes for #205)

### DIFF
--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -68,14 +68,24 @@ export const sendClientMetric = async (
       ...tags,
     };
 
-    // Add session and organization IDs if available
-    if (anamMetricsContext.sessionId) {
+    // Fill session/organization/attempt IDs from the global context, but only
+    // when the caller did not already supply them. Callers that pass their own
+    // context (e.g. the connection-milestones recorder, which pins each metric
+    // to the attempt it belongs to) are authoritative; the global singleton is
+    // mutated by every new attempt and must not overwrite a caller's snapshot.
+    if (anamMetricsContext.sessionId && metricTags.sessionId === undefined) {
       metricTags.sessionId = anamMetricsContext.sessionId;
     }
-    if (anamMetricsContext.organizationId) {
+    if (
+      anamMetricsContext.organizationId &&
+      metricTags.organizationId === undefined
+    ) {
       metricTags.organizationId = anamMetricsContext.organizationId;
     }
-    if (anamMetricsContext.attemptCorrelationId) {
+    if (
+      anamMetricsContext.attemptCorrelationId &&
+      metricTags.attemptCorrelationId === undefined
+    ) {
       metricTags.attemptCorrelationId = anamMetricsContext.attemptCorrelationId;
     }
 

--- a/src/lib/ConnectionMilestones.ts
+++ b/src/lib/ConnectionMilestones.ts
@@ -92,6 +92,24 @@ export class ClientConnectionMilestoneRecorder {
     this.sessionSuccessful = true;
     this.record('client_session_success', tags);
     this.publishIfNeeded();
+    // Once the success/publish decision has been made the recorder is done.
+    // Stop accumulating and release the buffer for the rest of the
+    // (potentially long-lived) session. Without this, a fast unsampled success
+    // — the default path, since connectionMilestoneSampleRatio defaults to 0 —
+    // never sets `published`, so the long-lived ICE/websocket event handlers
+    // keep appending to `milestones` for the entire call.
+    this.finalize();
+  }
+
+  /**
+   * Make the recorder inert and release its buffer. `published` gates
+   * record()/publish()/publishFailure(), so flipping it here stops all further
+   * recording and publishing. publish() (if it ran) already serialized the
+   * milestones synchronously, so clearing the buffer afterwards is safe.
+   */
+  private finalize() {
+    this.published = true;
+    this.milestones.length = 0;
   }
 
   public publishFailure(tags?: ConnectionMilestoneTags) {

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -614,8 +614,7 @@ export class StreamingClient {
           );
         }
         if (this.connectionReceivedAnswer) {
-          await this.peerConnection.addIceCandidate(candidate);
-          this.recordFirstRemoteIceCandidateApplied(candidate);
+          await this.addRemoteIceCandidate(candidate);
         } else {
           this.remoteIceCandidateBuffer.push(candidate);
         }
@@ -679,8 +678,30 @@ export class StreamingClient {
     const bufferedCandidates = [...this.remoteIceCandidateBuffer];
     this.remoteIceCandidateBuffer = [];
     for (const candidate of bufferedCandidates) {
-      await this.peerConnection?.addIceCandidate(candidate);
+      await this.addRemoteIceCandidate(candidate);
+    }
+  }
+
+  /**
+   * Add a single remote ICE candidate to the peer connection.
+   * Each candidate is added independently: a rejection on one candidate is
+   * logged and swallowed so it cannot abort the flush loop (dropping the
+   * remaining buffered candidates) or surface as an unhandled rejection from
+   * the ANSWER handler. The "first applied" milestone is only recorded after a
+   * genuine, successful add.
+   */
+  private async addRemoteIceCandidate(candidate: RTCIceCandidate) {
+    if (!this.peerConnection) {
+      return;
+    }
+    try {
+      await this.peerConnection.addIceCandidate(candidate);
       this.recordFirstRemoteIceCandidateApplied(candidate);
+    } catch (error) {
+      console.warn(
+        'StreamingClient - addRemoteIceCandidate: failed to add remote ICE candidate',
+        error,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Review fixes stacked on top of `ziollek/eng-2332-granular-webrtc-milestones` (#205). Three issues found while reviewing the connection-milestones telemetry:

- **ICE candidate flush regression (high):** `flushRemoteIceCandidateBuffer` was rewritten to `await addIceCandidate` sequentially, so a single rejected candidate aborted the loop and silently dropped the remaining buffered candidates (the buffer is cleared up front), and the rejection surfaced as an unhandled rejection from the ANSWER handler. Both add-sites now route through a shared `addRemoteIceCandidate()` helper that adds each candidate independently (per-candidate `try/catch`) and records the `first_remote_ice_candidate_applied` milestone only after a successful add. Sequential ordering is kept (order is irrelevant for ICE).
- **Recorder never finalized on the default path (medium):** with `connectionMilestoneSampleRatio` at its default of `0`, a fast successful connection never publishes, so `published` stayed `false` and the long-lived ICE/websocket handlers kept appending milestones for the whole session. `recordSessionSuccess()` now finalizes the recorder (stops recording + releases the buffer) once the publish decision is made.
- **Per-attempt context clobbered by the global singleton (medium):** `sendClientMetric` unconditionally overwrote `sessionId`/`organizationId`/`attemptCorrelationId` from the mutable global metrics context, discarding the recorder's per-attempt snapshot and risking mis-attributed metrics for deferred publishes. It now only fills those fields when the caller didn't already supply them (backward-compatible — no other caller passes them).

## Verification

- `npm run build:main` / `npm run build:module` (tsc)
- `npm run test:connection-milestones`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened WebRTC connection milestone telemetry to prevent dropped ICE candidates, endless recording after success, and mis-attributed metrics. Aligns with ENG-2332 granular connection milestones.

- **Bug Fixes**
  - Add remote ICE via `addRemoteIceCandidate()` with per-candidate try/catch, so one failure won’t abort the flush; record `first_remote_ice_candidate_applied` only on successful adds.
  - Finalize the recorder after `recordSessionSuccess()` decides publish, stopping further accumulation and releasing the buffer (covers default `connectionMilestoneSampleRatio = 0` path).
  - Update `sendClientMetric` to only backfill `sessionId`/`organizationId`/`attemptCorrelationId` from the global context when not provided, preserving per-attempt context for deferred publishes.

<sup>Written for commit 2ccd24bc44a751aa8b55adba37e13e4d2a9eb7d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

