### PR TITLE
ENG-2332 Store connection milestones as queryable rows

### DIFF
--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -8,10 +8,13 @@ export enum ClientMetricMeasurement {
   CLIENT_METRIC_MEASUREMENT_ERROR = 'client_error',
   CLIENT_METRIC_MEASUREMENT_CONNECTION_CLOSED = 'client_connection_closed',
   CLIENT_METRIC_MEASUREMENT_CONNECTION_ESTABLISHED = 'client_connection_established',
+  CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONE = 'client_connection_milestone',
   CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES = 'client_connection_milestones',
   CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT = 'client_session_attempt',
   CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS = 'client_session_success',
 }
+
+const CLIENT_METRICS_MAX_BATCH_SIZE = 50;
 
 let anamCurrentBaseUrl = DEFAULT_ANAM_METRICS_BASE_URL;
 let anamCurrentApiVersion = DEFAULT_ANAM_API_VERSION;
@@ -52,43 +55,27 @@ export const setMetricsContext = (context: Partial<AnamMetricsContext>) => {
   anamMetricsContext = { ...anamMetricsContext, ...context };
 };
 
+export interface ClientMetricPayload {
+  name: string;
+  value: string | number;
+  tags?: Record<string, string | number>;
+}
+
 export const sendClientMetric = async (
   name: string,
-  value: string,
+  value: string | number,
   tags?: Record<string, string | number>,
 ) => {
+  await sendClientMetrics([{ name, value, tags }]);
+};
+
+export const sendClientMetrics = async (metrics: ClientMetricPayload[]) => {
   // Skip sending metrics if disabled
-  if (metricsDisabled) {
+  if (metricsDisabled || metrics.length === 0) {
     return;
   }
 
   try {
-    const metricTags: Record<string, string | number> = {
-      ...CLIENT_METADATA,
-      ...tags,
-    };
-
-    // Fill session/organization/attempt IDs from the global context, but only
-    // when the caller did not already supply them. Callers that pass their own
-    // context (e.g. the connection-milestones recorder, which pins each metric
-    // to the attempt it belongs to) are authoritative; the global singleton is
-    // mutated by every new attempt and must not overwrite a caller's snapshot.
-    if (anamMetricsContext.sessionId && metricTags.sessionId === undefined) {
-      metricTags.sessionId = anamMetricsContext.sessionId;
-    }
-    if (
-      anamMetricsContext.organizationId &&
-      metricTags.organizationId === undefined
-    ) {
-      metricTags.organizationId = anamMetricsContext.organizationId;
-    }
-    if (
-      anamMetricsContext.attemptCorrelationId &&
-      metricTags.attemptCorrelationId === undefined
-    ) {
-      metricTags.attemptCorrelationId = anamMetricsContext.attemptCorrelationId;
-    }
-
     // Determine URL and headers based on API Gateway configuration
     const targetPath = `${anamCurrentApiVersion}/metrics/client`;
     let url: string;
@@ -105,18 +92,68 @@ export const sendClientMetric = async (
       url = `${anamCurrentBaseUrl}${targetPath}`;
     }
 
-    await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        name,
-        value,
-        tags: metricTags,
-      }),
-    });
+    const normalizedMetrics = metrics.map((metric) => ({
+      ...metric,
+      tags: buildMetricTags(metric.tags),
+    }));
+
+    for (
+      let batchStart = 0;
+      batchStart < normalizedMetrics.length;
+      batchStart += CLIENT_METRICS_MAX_BATCH_SIZE
+    ) {
+      const batch = normalizedMetrics.slice(
+        batchStart,
+        batchStart + CLIENT_METRICS_MAX_BATCH_SIZE,
+      );
+      const body =
+        batch.length === 1
+          ? batch[0]
+          : {
+              metrics: batch,
+            };
+
+      await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    }
   } catch (error) {
-    console.error('Failed to send error metric:', error);
+    console.error('Failed to send client metric:', error);
   }
+};
+
+const buildMetricTags = (
+  tags?: Record<string, string | number>,
+): Record<string, string | number> => {
+  const metricTags: Record<string, string | number> = {
+    ...CLIENT_METADATA,
+    ...tags,
+  };
+
+  // Fill session/organization/attempt IDs from the global context, but only
+  // when the caller did not already supply them. Callers that pass their own
+  // context (e.g. the connection-milestones recorder, which pins each metric
+  // to the attempt it belongs to) are authoritative; the global singleton is
+  // mutated by every new attempt and must not overwrite a caller's snapshot.
+  if (anamMetricsContext.sessionId && metricTags.sessionId === undefined) {
+    metricTags.sessionId = anamMetricsContext.sessionId;
+  }
+  if (
+    anamMetricsContext.organizationId &&
+    metricTags.organizationId === undefined
+  ) {
+    metricTags.organizationId = anamMetricsContext.organizationId;
+  }
+  if (
+    anamMetricsContext.attemptCorrelationId &&
+    metricTags.attemptCorrelationId === undefined
+  ) {
+    metricTags.attemptCorrelationId = anamMetricsContext.attemptCorrelationId;
+  }
+
+  return metricTags;
 };
 
 export interface RTCStatsJsonReport {

--- a/src/lib/ConnectionMilestones.ts
+++ b/src/lib/ConnectionMilestones.ts
@@ -1,7 +1,8 @@
 import {
   AnamMetricsContext,
+  ClientMetricPayload,
   ClientMetricMeasurement,
-  sendClientMetric,
+  sendClientMetrics,
 } from './ClientMetrics';
 import { ConnectionMilestoneMetricsOptions } from '../types/ConnectionMilestoneMetricsOptions';
 
@@ -104,8 +105,8 @@ export class ClientConnectionMilestoneRecorder {
   /**
    * Make the recorder inert and release its buffer. `published` gates
    * record()/publish()/publishFailure(), so flipping it here stops all further
-   * recording and publishing. publish() (if it ran) already serialized the
-   * milestones synchronously, so clearing the buffer afterwards is safe.
+   * recording and publishing. publish() (if it ran) already built the metric
+   * payloads synchronously, so clearing the buffer afterwards is safe.
    */
   private finalize() {
     this.published = true;
@@ -145,8 +146,7 @@ export class ClientConnectionMilestoneRecorder {
     }
 
     this.published = true;
-    const serializedMilestones = JSON.stringify(this.milestones);
-    const metricTags = sanitizeMetricTags({
+    const summaryTags = sanitizeMetricTags({
       ...tags,
       ...this.context,
       publishReason: reason,
@@ -155,14 +155,28 @@ export class ClientConnectionMilestoneRecorder {
       connectionMilestoneSampleRatio: this.sampleRatio,
       slowConnectionThresholdMs: this.slowConnectionThresholdMs,
       wasSampled: this.sampled ? 1 : 0,
-      milestones: serializedMilestones,
     });
 
-    void sendClientMetric(
-      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES,
-      '1',
-      metricTags,
-    );
+    const metrics: ClientMetricPayload[] = [
+      {
+        name: ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES,
+        value: '1',
+        tags: summaryTags,
+      },
+      ...this.milestones.map((milestone, index) => ({
+        name: ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONE,
+        value: milestone.elapsedMs,
+        tags: sanitizeMetricTags({
+          ...this.context,
+          publishReason: reason,
+          milestone: milestone.name,
+          sequence: index,
+          ...milestone.tags,
+        }),
+      })),
+    ];
+
+    void sendClientMetrics(metrics);
   }
 
   private elapsedMs(): number {

--- a/test/connectionMilestonesHarness.js
+++ b/test/connectionMilestonesHarness.js
@@ -13,6 +13,25 @@ const resetRequests = () => {
   requests.length = 0;
 };
 
+const getMetrics = (request) => request.metrics ?? [request];
+const getSummaryMetric = (request) =>
+  getMetrics(request).find(
+    (metric) => metric.name === 'client_connection_milestones',
+  );
+const getDetailMetrics = (request) =>
+  getMetrics(request).filter(
+    (metric) => metric.name === 'client_connection_milestone',
+  );
+const assertNoSerializedMilestoneTag = (request) => {
+  getMetrics(request).forEach((metric) => {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(metric.tags, 'milestones'),
+      false,
+      `${metric.name} should not include serialized milestones tag`,
+    );
+  });
+};
+
 const createRecorder = ({
   sampleRatio = 0,
   slowThresholdMs = 5000,
@@ -29,8 +48,6 @@ const createRecorder = ({
     random: () => randomValue,
     now,
   });
-
-const parseMilestones = (request) => JSON.parse(request.tags.milestones);
 
 async function runHarness() {
   let nowMs = 0;
@@ -53,12 +70,27 @@ async function runHarness() {
   nowMs = 100;
   recorder.recordSessionSuccess({ detectionMethod: 'harness' });
   assert.equal(requests.length, 1, 'sampled success should publish once');
-  assert.equal(requests[0].name, 'client_connection_milestones');
-  assert.equal(requests[0].tags.publishReason, 'sampled');
+  assert.equal(getMetrics(requests[0]).length, 3);
+  assertNoSerializedMilestoneTag(requests[0]);
+  const sampledSummary = getSummaryMetric(requests[0]);
+  const sampledDetails = getDetailMetrics(requests[0]);
+  assert.equal(sampledSummary.tags.publishReason, 'sampled');
+  assert.equal(sampledSummary.tags.milestoneCount, 2);
+  assert.equal(sampledDetails.length, 2);
   assert.deepEqual(
-    parseMilestones(requests[0]).map((milestone) => milestone.name),
+    sampledDetails.map((metric) => metric.tags.milestone),
     ['client_session_attempt', 'client_session_success'],
   );
+  assert.deepEqual(
+    sampledDetails.map((metric) => metric.value),
+    [0, 100],
+  );
+  assert.deepEqual(
+    sampledDetails.map((metric) => metric.tags.sequence),
+    [0, 1],
+  );
+  assert.equal(sampledDetails[1].tags.detectionMethod, 'harness');
+  assert.equal(sampledDetails[1].tags.publishReason, 'sampled');
 
   resetRequests();
   nowMs = 0;
@@ -69,8 +101,16 @@ async function runHarness() {
   nowMs = 75;
   recorder.recordSessionSuccess({ detectionMethod: 'harness' });
   assert.equal(requests.length, 1, 'slow success should publish once');
-  assert.equal(requests[0].tags.publishReason, 'slow');
-  assert.equal(requests[0].tags.attemptDurationMs, 75);
+  assertNoSerializedMilestoneTag(requests[0]);
+  const slowSummary = getSummaryMetric(requests[0]);
+  const slowDetails = getDetailMetrics(requests[0]);
+  assert.equal(slowSummary.tags.publishReason, 'slow');
+  assert.equal(slowSummary.tags.attemptDurationMs, 75);
+  assert.equal(slowDetails.length, 2);
+  assert.deepEqual(
+    slowDetails.map((metric) => metric.tags.milestone),
+    ['client_session_attempt', 'client_session_success'],
+  );
 
   resetRequests();
   nowMs = 0;
@@ -78,8 +118,16 @@ async function runHarness() {
   nowMs = 25;
   recorder.publishFailure({ failureStage: 'harness' });
   assert.equal(requests.length, 1, 'failed attempt should publish once');
-  assert.equal(requests[0].tags.publishReason, 'failed');
-  assert.equal(requests[0].tags.failureStage, 'harness');
+  assertNoSerializedMilestoneTag(requests[0]);
+  const failureSummary = getSummaryMetric(requests[0]);
+  const failureDetails = getDetailMetrics(requests[0]);
+  assert.equal(failureSummary.tags.publishReason, 'failed');
+  assert.equal(failureSummary.tags.failureStage, 'harness');
+  assert.deepEqual(
+    failureDetails.map((metric) => metric.tags.milestone),
+    ['client_session_attempt', 'connection_attempt_failed'],
+  );
+  assert.equal(failureDetails[1].tags.failureStage, 'harness');
 }
 
 runHarness()


### PR DESCRIPTION
## Problem

The first ENG-2332 SDK change used the batching endpoint, but it only sent one `client_connection_milestones` metric per attempt. The detailed milestone timeline was serialized into a single `tags.milestones` JSON string on that summary row.

That shape does not survive the Lab metrics pipeline. Lab caps tag values, so slow attempts with many milestones only retain the first slice of the serialized JSON. The batch exists, but storage still only has one signal row, with one ingestion timestamp, and the per-milestone details are not queryable.

## Data shape change

Before, the SDK sent one metric with all milestone details embedded in a tag:

```json
{
  "name": "client_connection_milestones",
  "value": "1",
  "tags": {
    "sessionId": "session-1",
    "attemptCorrelationId": "attempt-1",
    "publishReason": "slow",
    "attemptDurationMs": 11937,
    "milestoneCount": 31,
    "milestones": "[{\"name\":\"client_session_attempt\",\"elapsedMs\":0},{\"name\":\"start_session_request_started\",\"elapsedMs\":1},...]"
  }
}
```

After, the SDK sends a batch with one summary row and one row per milestone:

```json
{
  "metrics": [
    {
      "name": "client_connection_milestones",
      "value": "1",
      "tags": {
        "sessionId": "session-1",
        "attemptCorrelationId": "attempt-1",
        "publishReason": "slow",
        "attemptDurationMs": 11937,
        "milestoneCount": 31
      }
    },
    {
      "name": "client_connection_milestone",
      "value": 0,
      "tags": {
        "sessionId": "session-1",
        "attemptCorrelationId": "attempt-1",
        "publishReason": "slow",
        "milestone": "client_session_attempt",
        "sequence": 0
      }
    },
    {
      "name": "client_connection_milestone",
      "value": 744,
      "tags": {
        "sessionId": "session-1",
        "attemptCorrelationId": "attempt-1",
        "publishReason": "slow",
        "milestone": "start_session_request_completed",
        "sequence": 2
      }
    }
  ]
}
```

With the new shape, each milestone is stored as its own queryable signal. The stored row timestamp is still the batch ingestion time, while the milestone timing is represented by the metric value (`elapsedMs`) plus `sequence` for ordering.

## Change

- Keep the existing `client_connection_milestones` summary metric for attempt-level fields like `publishReason`, `attemptDurationMs`, and `milestoneCount`.
- Remove the serialized `milestones` tag from the summary metric.
- Add one `client_connection_milestone` metric per recorded milestone in the same batch.
- Store each milestone elapsed time as the metric value, with queryable tags for attempt context, `publishReason`, `milestone`, `sequence`, and milestone-specific details where available.
- Add a reusable batched `sendClientMetrics` helper while preserving `sendClientMetric` compatibility for existing callers.

## Verification

- `npm run build`
- `npm run test:connection-milestones`