### PR TITLE
feat(sdk): automatic ICE restart for network recovery

### DIFF
--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -12,6 +12,7 @@ export enum ClientMetricMeasurement {
   CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONES = 'client_connection_milestones',
   CLIENT_METRIC_MEASUREMENT_SESSION_ATTEMPT = 'client_session_attempt',
   CLIENT_METRIC_MEASUREMENT_SESSION_SUCCESS = 'client_session_success',
+  CLIENT_METRIC_MEASUREMENT_ICE_RESTART = 'client_ice_restart',
 }
 
 const CLIENT_METRICS_MAX_BATCH_SIZE = 50;
@@ -79,7 +80,7 @@ export const sendClientMetrics = async (metrics: ClientMetricPayload[]) => {
     // Determine URL and headers based on API Gateway configuration
     const targetPath = `${anamCurrentApiVersion}/metrics/client`;
     let url: string;
-    let headers: Record<string, string> = {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
 

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -28,6 +28,7 @@ export class SignallingClient {
   private socket: WebSocket | null = null;
   private permanentlyClosed = false;
   private heartBeatIntervalRef: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private connectionMilestones: ClientConnectionMilestoneRecorder | undefined;
 
@@ -110,6 +111,7 @@ export class SignallingClient {
   }
 
   public connect(): WebSocket {
+    this.clearReconnectTimer();
     this.connectionMilestones?.record('websocket_connecting', {
       attemptNumber: this.wsConnectionAttempts + 1,
     });
@@ -226,6 +228,7 @@ export class SignallingClient {
   }
 
   private closeSocket() {
+    this.clearReconnectTimer();
     if (this.socket) {
       this.socket.close();
       this.socket = null;
@@ -259,6 +262,13 @@ export class SignallingClient {
     }
   }
 
+  private clearReconnectTimer() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
   private async onClose(event?: CloseEvent) {
     this.connectionMilestones?.record('websocket_closed', {
       attemptNumber: this.wsConnectionAttempts + 1,
@@ -276,7 +286,11 @@ export class SignallingClient {
         delayMs: retryDelayMs,
       });
       this.socket = null;
-      setTimeout(() => {
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+      }
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
         this.connect();
       }, retryDelayMs);
     } else {

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -26,6 +26,7 @@ export class SignallingClient {
   private sendingBuffer: SignalMessage[] = [];
   private wsConnectionAttempts = 0;
   private socket: WebSocket | null = null;
+  private permanentlyClosed = false;
   private heartBeatIntervalRef: ReturnType<typeof setInterval> | null = null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private connectionMilestones: ClientConnectionMilestoneRecorder | undefined;
@@ -117,6 +118,47 @@ export class SignallingClient {
     this.socket.onclose = this.onClose.bind(this);
     this.socket.onerror = this.onError.bind(this);
     return this.socket;
+  }
+
+  /**
+   * Force a fresh signalling socket for an ICE restart. A network switch can
+   * leave the existing socket half-open (readyState stays OPEN with no 'close'
+   * event), so a restart offer sent on it is silently dropped. Detach the stale
+   * socket's handlers so its eventual close does not drive the reconnect
+   * backoff, drop it, and open a new connection — whose close/error events fire
+   * normally, re-enabling the auto-reconnect loop until the new network path is
+   * reachable.
+   */
+  public reconnectForIceRestart(): void {
+    if (this.stopSignal || this.permanentlyClosed) {
+      return;
+    }
+    if (this.socket) {
+      this.socket.onopen = null;
+      this.socket.onclose = null;
+      this.socket.onerror = null;
+      this.socket.onmessage = null;
+      try {
+        this.socket.close();
+      } catch {
+        // A half-open socket may throw on close; the reconnect proceeds regardless.
+      }
+      this.socket = null;
+    }
+    if (this.heartBeatIntervalRef) {
+      clearInterval(this.heartBeatIntervalRef);
+      this.heartBeatIntervalRef = null;
+    }
+    this.wsConnectionAttempts = 0;
+    this.connect();
+  }
+
+  public isConnected(): boolean {
+    return this.socket?.readyState === WebSocket.OPEN;
+  }
+
+  public isPermanentlyClosed(): boolean {
+    return this.permanentlyClosed || this.stopSignal;
   }
 
   public async sendOffer(localDescription: RTCSessionDescription) {
@@ -213,6 +255,7 @@ export class SignallingClient {
         AnamEvent.CONNECTION_CLOSED,
         ConnectionClosedCode.SIGNALLING_CLIENT_CONNECTION_FAILURE,
       );
+      this.permanentlyClosed = true;
     }
   }
 
@@ -249,6 +292,7 @@ export class SignallingClient {
         AnamEvent.CONNECTION_CLOSED,
         ConnectionClosedCode.SIGNALLING_CLIENT_CONNECTION_FAILURE,
       );
+      this.permanentlyClosed = true;
     }
   }
 

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -169,6 +169,15 @@ export class SignallingClient {
     this.connect();
   }
 
+  /**
+   * Ends the ICE-restart reconnect episode: subsequent closes use the default
+   * retry budget again. Called by StreamingClient when the restart succeeds,
+   * is cancelled, or exhausts its attempts.
+   */
+  public endIceRestartReconnect(): void {
+    this.iceRestartReconnectInProgress = false;
+  }
+
   public isConnected(): boolean {
     return this.socket?.readyState === WebSocket.OPEN;
   }
@@ -263,7 +272,9 @@ export class SignallingClient {
         attemptNumber: this.wsConnectionAttempts + 1,
       });
       this.wsConnectionAttempts = 0;
-      this.iceRestartReconnectInProgress = false;
+      // Keep iceRestartReconnectInProgress (the extended retry budget) until
+      // StreamingClient ends the episode: a socket that opens briefly and drops
+      // again mid-restart must not fall back to the short default budget.
       this.flushSendingBuffer();
       socket.onmessage = this.onMessage.bind(this);
       this.startSendingHeartBeats();

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -14,6 +14,10 @@ import { TalkMessageStreamPayload } from '../types/signalling/TalkMessageStreamP
 
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5;
 const DEFAULT_WS_RECONNECTION_ATTEMPTS = 5;
+// Long enough to cover StreamingClient's full restart envelope:
+// 3 attempts * (5s websocket-open wait + 3s restart watchdog) = 24s.
+// With 100ms linear backoff this keeps signalling non-terminal for ~30s.
+const ICE_RESTART_WS_RECONNECTION_ATTEMPTS = 24;
 
 export class SignallingClient {
   private publicEventEmitter: PublicEventEmitter;
@@ -27,6 +31,7 @@ export class SignallingClient {
   private wsConnectionAttempts = 0;
   private socket: WebSocket | null = null;
   private permanentlyClosed = false;
+  private iceRestartReconnectInProgress = false;
   private heartBeatIntervalRef: ReturnType<typeof setInterval> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
@@ -115,26 +120,34 @@ export class SignallingClient {
     this.connectionMilestones?.record('websocket_connecting', {
       attemptNumber: this.wsConnectionAttempts + 1,
     });
-    this.socket = new WebSocket(this.url.href);
-    this.socket.onopen = this.onOpen.bind(this);
-    this.socket.onclose = this.onClose.bind(this);
-    this.socket.onerror = this.onError.bind(this);
-    return this.socket;
+    const socket = new WebSocket(this.url.href);
+    this.socket = socket;
+    socket.onopen = () => {
+      void this.onOpen(socket);
+    };
+    socket.onclose = (event) => {
+      void this.onClose(socket, event);
+    };
+    socket.onerror = (event) => {
+      this.onError(socket, event);
+    };
+    return socket;
   }
 
   /**
    * Force a fresh signalling socket for an ICE restart. A network switch can
    * leave the existing socket half-open (readyState stays OPEN with no 'close'
    * event), so a restart offer sent on it is silently dropped. Detach the stale
-   * socket's handlers so its eventual close does not drive the reconnect
-   * backoff, drop it, and open a new connection — whose close/error events fire
-   * normally, re-enabling the auto-reconnect loop until the new network path is
-   * reachable.
+   * socket's handlers so its eventual close does not drive the reconnect backoff,
+   * drop it, and open a new connection. While the new network path is still dead,
+   * use an ICE-restart-specific retry budget so signalling does not terminally
+   * close before StreamingClient's websocket-open wait can time out and retry.
    */
   public reconnectForIceRestart(): void {
     if (this.stopSignal || this.permanentlyClosed) {
       return;
     }
+    this.clearReconnectTimer();
     if (this.socket) {
       this.socket.onopen = null;
       this.socket.onclose = null;
@@ -152,6 +165,7 @@ export class SignallingClient {
       this.heartBeatIntervalRef = null;
     }
     this.wsConnectionAttempts = 0;
+    this.iceRestartReconnectInProgress = true;
     this.connect();
   }
 
@@ -229,6 +243,7 @@ export class SignallingClient {
 
   private closeSocket() {
     this.clearReconnectTimer();
+    this.iceRestartReconnectInProgress = false;
     if (this.socket) {
       this.socket.close();
       this.socket = null;
@@ -239,17 +254,18 @@ export class SignallingClient {
     }
   }
 
-  private async onOpen(): Promise<void> {
-    if (!this.socket) {
-      throw new Error('SignallingClient - onOpen: socket is null');
+  private async onOpen(socket: WebSocket): Promise<void> {
+    if (this.socket !== socket) {
+      return;
     }
     try {
       this.connectionMilestones?.record('websocket_open', {
         attemptNumber: this.wsConnectionAttempts + 1,
       });
       this.wsConnectionAttempts = 0;
+      this.iceRestartReconnectInProgress = false;
       this.flushSendingBuffer();
-      this.socket.onmessage = this.onMessage.bind(this);
+      socket.onmessage = this.onMessage.bind(this);
       this.startSendingHeartBeats();
       this.internalEventEmitter.emit(InternalEvent.WEB_SOCKET_OPEN);
     } catch (e) {
@@ -269,7 +285,10 @@ export class SignallingClient {
     }
   }
 
-  private async onClose(event?: CloseEvent) {
+  private async onClose(socket: WebSocket, event?: CloseEvent) {
+    if (this.socket !== socket) {
+      return;
+    }
     this.connectionMilestones?.record('websocket_closed', {
       attemptNumber: this.wsConnectionAttempts + 1,
       closeCode: event?.code,
@@ -279,21 +298,21 @@ export class SignallingClient {
     if (this.stopSignal) {
       return;
     }
-    if (this.wsConnectionAttempts <= this.maxWsReconnectionAttempts) {
+    const maxReconnectionAttempts = this.getMaxReconnectionAttempts();
+    if (this.wsConnectionAttempts <= maxReconnectionAttempts) {
       const retryDelayMs = 100 * this.wsConnectionAttempts;
       this.connectionMilestones?.record('websocket_retry_scheduled', {
         attemptNumber: this.wsConnectionAttempts + 1,
         delayMs: retryDelayMs,
       });
       this.socket = null;
-      if (this.reconnectTimer) {
-        clearTimeout(this.reconnectTimer);
-      }
+      this.clearReconnectTimer();
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null;
         this.connect();
       }, retryDelayMs);
     } else {
+      this.clearReconnectTimer();
       if (this.heartBeatIntervalRef) {
         clearInterval(this.heartBeatIntervalRef);
         this.heartBeatIntervalRef = null;
@@ -306,12 +325,24 @@ export class SignallingClient {
         AnamEvent.CONNECTION_CLOSED,
         ConnectionClosedCode.SIGNALLING_CLIENT_CONNECTION_FAILURE,
       );
+      this.iceRestartReconnectInProgress = false;
       this.permanentlyClosed = true;
     }
   }
 
-  private onError(event: Event) {
-    if (this.stopSignal) {
+  private getMaxReconnectionAttempts(): number {
+    if (!this.iceRestartReconnectInProgress) {
+      return this.maxWsReconnectionAttempts;
+    }
+
+    return Math.max(
+      this.maxWsReconnectionAttempts,
+      ICE_RESTART_WS_RECONNECTION_ATTEMPTS,
+    );
+  }
+
+  private onError(socket: WebSocket, event: Event) {
+    if (this.stopSignal || this.socket !== socket) {
       return;
     }
     this.connectionMilestones?.record('websocket_error', {

--- a/src/modules/SignallingClient.ts
+++ b/src/modules/SignallingClient.ts
@@ -144,7 +144,7 @@ export class SignallingClient {
    * close before StreamingClient's websocket-open wait can time out and retry.
    */
   public reconnectForIceRestart(): void {
-    if (this.stopSignal || this.permanentlyClosed) {
+    if (this.isPermanentlyClosed()) {
       return;
     }
     this.clearReconnectTimer();
@@ -155,8 +155,12 @@ export class SignallingClient {
       this.socket.onmessage = null;
       try {
         this.socket.close();
-      } catch {
+      } catch (err) {
         // A half-open socket may throw on close; the reconnect proceeds regardless.
+        console.warn(
+          'SignallingClient - reconnectForIceRestart: error closing stale socket',
+          err,
+        );
       }
       this.socket = null;
     }

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -629,9 +629,15 @@ export class StreamingClient {
             'StreamingClient - setRemoteDescription(answer) failed',
             err,
           );
-          if (!this.isAwaitingRestartAnswer()) {
+          if (
+            !this.connectionEstablishedEmitted &&
+            !this.isAwaitingRestartAnswer()
+          ) {
             // Initial-connection answer: no restart watchdog will retry, so
-            // surface the failure instead of hanging the connection.
+            // surface the failure instead of hanging the connection. Once the
+            // session has been established, any answer is a restart answer
+            // (even if ICE recovered on its own and cleared the restart flags
+            // before it arrived) — ICE-failure handling owns recovery then.
             this.handleWebrtcFailure(err);
           }
           break; // restart answers: let the ICE restart watchdog retry
@@ -1002,6 +1008,9 @@ export class StreamingClient {
       const currentIceState = this.peerConnection.iceConnectionState;
       if (currentIceState === 'connected' || currentIceState === 'completed') {
         this.iceRestartInProgress = false;
+        // If ICE reconnected before reconnectForIceRestart() set the flag, the
+        // connected handler couldn't have cleared it — end the episode here too.
+        this.signallingClient.endIceRestartReconnect();
         return;
       }
 

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -40,6 +40,10 @@ import { ToolCallManager } from './ToolCallManager';
 const SUCCESS_METRIC_POLLING_TIMEOUT_MS = 15000; // After this time we will stop polling for the first frame and consider the session a failure.
 const STATS_COLLECTION_INTERVAL_MS = 5000;
 const ICE_CANDIDATE_POOL_SIZE = 2; // Optimisation to speed up connection time
+const MAX_ICE_RESTART_ATTEMPTS = 3;
+const ICE_DISCONNECTED_GRACE_MS = 2000;
+const ICE_RESTART_WATCHDOG_MS = 3000;
+const ENSURE_WS_OPEN_TIMEOUT_MS = 5000;
 
 export class StreamingClient {
   private publicEventEmitter: PublicEventEmitter;
@@ -51,6 +55,16 @@ export class StreamingClient {
   private rtcConfiguration: RTCConfiguration | undefined;
   private apiGatewayConfig: ApiGatewayConfig | undefined;
   private peerConnection: RTCPeerConnection | null = null;
+  private connectionEstablishedEmitted = false;
+  private iceRestartInProgress = false;
+  private iceRestartAttempts = 0;
+  private iceRestartStopped = false; // set on shutdown; halts all restart activity
+  private iceDisconnectedGraceTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  private iceRestartWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingWsOpenListener: (() => void) | null = null;
+  private pendingWsOpenTimeout: ReturnType<typeof setTimeout> | null = null;
+  private pendingWsOpenReject: ((reason?: unknown) => void) | null = null;
   private connectionReceivedAnswer = false;
   private remoteIceCandidateBuffer: RTCIceCandidate[] = [];
   private inputAudioStream: MediaStream | null = null;
@@ -737,30 +751,225 @@ export class StreamingClient {
   }
 
   private onIceConnectionStateChange() {
-    const iceConnectionState = this.peerConnection?.iceConnectionState;
-    if (iceConnectionState) {
+    const state = this.peerConnection?.iceConnectionState;
+    if (state) {
       this.connectionMilestones?.record('ice_connection_state_changed', {
-        iceConnectionState,
+        iceConnectionState: state,
       });
     }
-    if (
-      this.peerConnection?.iceConnectionState === 'connected' ||
-      this.peerConnection?.iceConnectionState === 'completed'
-    ) {
-      if (!this.connectionEstablishedMilestoneRecorded) {
-        this.connectionEstablishedMilestoneRecorded = true;
-        this.connectionMilestones?.record('client_connection_established', {
-          iceConnectionState: this.peerConnection.iceConnectionState,
+    switch (state) {
+      case 'connected':
+      case 'completed':
+        this.clearIceDisconnectedGraceTimer();
+        this.clearIceRestartWatchdog();
+        this.iceRestartInProgress = false;
+        this.iceRestartAttempts = 0;
+        if (!this.connectionEstablishedMilestoneRecorded) {
+          this.connectionEstablishedMilestoneRecorded = true;
+          this.connectionMilestones?.record('client_connection_established', {
+            iceConnectionState: state,
+          });
+        }
+        if (!this.connectionEstablishedEmitted) {
+          this.connectionEstablishedEmitted = true;
+          this.publicEventEmitter.emit(AnamEvent.CONNECTION_ESTABLISHED);
+        }
+        this.startStatsCollection(); // idempotent (guards on statsCollectionInterval)
+        break;
+      case 'disconnected':
+        this.scheduleIceRestartAfterGrace();
+        break;
+      case 'failed':
+        this.clearIceDisconnectedGraceTimer();
+        this.connectionMilestones?.publishFailure({
+          failureStage: 'ice_connection',
+          iceConnectionState: state,
         });
+        void this.restartIce();
+        break;
+    }
+  }
+
+  private clearIceDisconnectedGraceTimer() {
+    if (this.iceDisconnectedGraceTimer) {
+      clearTimeout(this.iceDisconnectedGraceTimer);
+      this.iceDisconnectedGraceTimer = null;
+    }
+  }
+
+  private clearIceRestartWatchdog() {
+    if (this.iceRestartWatchdogTimer) {
+      clearTimeout(this.iceRestartWatchdogTimer);
+      this.iceRestartWatchdogTimer = null;
+    }
+  }
+
+  // Clears the pending ensureSignallingConnected wait (timeout + listener).
+  private clearPendingWsOpenWait() {
+    if (this.pendingWsOpenTimeout) {
+      clearTimeout(this.pendingWsOpenTimeout);
+      this.pendingWsOpenTimeout = null;
+    }
+    if (this.pendingWsOpenListener) {
+      this.internalEventEmitter.removeListener(
+        InternalEvent.WEB_SOCKET_OPEN,
+        this.pendingWsOpenListener,
+      );
+      this.pendingWsOpenListener = null;
+    }
+    this.pendingWsOpenReject = null;
+  }
+
+  // Stops all restart activity: timers, pending WS wait, and the in-progress gate.
+  private cancelIceRestart() {
+    this.clearIceDisconnectedGraceTimer();
+    this.clearIceRestartWatchdog();
+    const reject = this.pendingWsOpenReject;
+    this.clearPendingWsOpenWait();
+    if (reject) reject(new Error('ice restart cancelled'));
+    this.iceRestartInProgress = false;
+  }
+
+  private scheduleIceRestartAfterGrace() {
+    if (
+      this.iceRestartStopped ||
+      this.iceRestartInProgress ||
+      this.iceDisconnectedGraceTimer
+    ) {
+      return;
+    }
+    this.iceDisconnectedGraceTimer = setTimeout(() => {
+      this.iceDisconnectedGraceTimer = null;
+      if (this.iceRestartStopped) return;
+      const state = this.peerConnection?.iceConnectionState;
+      if (state === 'disconnected' || state === 'failed') {
+        void this.restartIce();
       }
-      this.publicEventEmitter.emit(AnamEvent.CONNECTION_ESTABLISHED);
-      // Start collecting stats every 5 seconds
-      this.startStatsCollection();
-    } else if (this.peerConnection?.iceConnectionState === 'failed') {
-      this.connectionMilestones?.publishFailure({
-        failureStage: 'ice_connection',
-        iceConnectionState: this.peerConnection.iceConnectionState,
-      });
+    }, ICE_DISCONNECTED_GRACE_MS);
+  }
+
+  /**
+   * Resolve once the signalling WebSocket is open (it auto-reconnects on close),
+   * or reject if it is terminally closed / times out. Restart offers must never
+   * be sent on a dead socket. Timeout + listener are stored so shutdown can clear
+   * them (see clearPendingWsOpenWait).
+   */
+  private ensureSignallingConnected(): Promise<void> {
+    if (this.signallingClient.isConnected()) {
+      return Promise.resolve();
+    }
+    if (this.signallingClient.isPermanentlyClosed()) {
+      return Promise.reject(new Error('signalling permanently closed'));
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.pendingWsOpenReject = reject;
+      this.pendingWsOpenTimeout = setTimeout(() => {
+        this.clearPendingWsOpenWait();
+        reject(new Error('timed out waiting for signalling WebSocket'));
+      }, ENSURE_WS_OPEN_TIMEOUT_MS);
+      const onOpen = () => {
+        this.clearPendingWsOpenWait();
+        resolve();
+      };
+      this.pendingWsOpenListener = onOpen;
+      this.internalEventEmitter.addListener(
+        InternalEvent.WEB_SOCKET_OPEN,
+        onOpen,
+      );
+    });
+  }
+
+  /**
+   * Automatic ICE restart. Mints a new offer with fresh ICE credentials and
+   * sends it over the existing channel. Bounded retries via a watchdog; on
+   * exhaustion or terminal signalling, falls back to the WebRTC-failure path.
+   */
+  private async restartIce(): Promise<void> {
+    if (
+      !this.peerConnection ||
+      this.iceRestartInProgress ||
+      this.iceRestartStopped
+    ) {
+      return;
+    }
+    if (this.signallingClient.isPermanentlyClosed()) {
+      // Session is already ending via the signalling layer; stop spinning.
+      this.cancelIceRestart();
+      return;
+    }
+    if (this.iceRestartAttempts >= MAX_ICE_RESTART_ATTEMPTS) {
+      console.error('StreamingClient - restartIce: exhausted attempts');
+      this.cancelIceRestart();
+      this.handleWebrtcFailure(
+        'The connection to our servers was lost. Please try again.',
+      );
+      return;
+    }
+
+    // Set the in-progress gate BEFORE any await so a concurrent trigger
+    // (watchdog retry + ICE 'failed' event) cannot start a second restart.
+    this.iceRestartInProgress = true;
+    this.iceRestartAttempts += 1;
+    try {
+      // Avoid offer glare: only start a fresh offer from a stable signalling state.
+      if (this.peerConnection.signalingState !== 'stable') {
+        await this.peerConnection.setLocalDescription({ type: 'rollback' });
+      }
+      // On the first attempt of a restart episode, force a fresh signalling
+      // socket. A network switch can leave the old one half-open (readyState
+      // still OPEN, no close event), so the offer would be sent into a dead
+      // socket and never reach the server. Retries (attempt > 1) reuse the
+      // now-live socket so an in-flight answer isn't dropped.
+      if (this.iceRestartAttempts === 1) {
+        this.signallingClient.reconnectForIceRestart();
+      }
+      await this.ensureSignallingConnected();
+      if (this.iceRestartStopped) return;
+      // ICE may have recovered on its own while we waited for signalling.
+      const currentIceState = this.peerConnection.iceConnectionState;
+      if (currentIceState === 'connected' || currentIceState === 'completed') {
+        this.iceRestartInProgress = false;
+        return;
+      }
+
+      this.connectionReceivedAnswer = false;
+      this.remoteIceCandidateBuffer = [];
+
+      const offer = await this.peerConnection.createOffer({ iceRestart: true });
+      await this.peerConnection.setLocalDescription(offer);
+      if (!this.peerConnection.localDescription) {
+        throw new Error('null local description after ICE restart offer');
+      }
+      await this.signallingClient.sendOffer(
+        this.peerConnection.localDescription,
+      );
+
+      this.clearIceRestartWatchdog();
+      this.iceRestartWatchdogTimer = setTimeout(() => {
+        this.iceRestartWatchdogTimer = null;
+        this.iceRestartInProgress = false;
+        if (this.iceRestartStopped) return;
+        const state = this.peerConnection?.iceConnectionState;
+        if (state === 'connected' || state === 'completed') {
+          return;
+        }
+        void this.restartIce();
+      }, ICE_RESTART_WATCHDOG_MS);
+    } catch (err) {
+      console.error('StreamingClient - restartIce: error', err);
+      this.iceRestartInProgress = false;
+      if (
+        this.iceRestartStopped ||
+        this.signallingClient.isPermanentlyClosed()
+      ) {
+        this.cancelIceRestart();
+        return; // signalling layer already emitted CONNECTION_CLOSED
+      }
+      this.clearIceRestartWatchdog();
+      this.iceRestartWatchdogTimer = setTimeout(() => {
+        this.iceRestartWatchdogTimer = null;
+        void this.restartIce();
+      }, ICE_RESTART_WATCHDOG_MS);
     }
   }
 
@@ -1147,6 +1356,8 @@ export class StreamingClient {
   }
 
   private async shutdown() {
+    this.iceRestartStopped = true;
+    this.cancelIceRestart();
     if (this.showPeerConnectionStatsReport) {
       const stats = await this.peerConnection?.getStats();
       if (stats) {

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -671,8 +671,7 @@ export class StreamingClient {
       }
       case SignalMessageAction.END_SESSION:
         const reason = signalMessage.payload as string;
-        // Server ended the session mid-restart: count the episode as aborted
-        // (unlike a user hang-up, which deliberately emits nothing).
+        // Server-ended session mid-restart counts as aborted; user hang-up doesn't.
         this.sendIceRestartMetric('aborted');
         this.connectionMilestones?.publishFailure({
           failureStage: 'server_closed_connection',
@@ -845,12 +844,8 @@ export class StreamingClient {
     }
   }
 
-  // One metric per restart episode, sent at episode end; complements the
-  // engine's server-side ICE recovery metrics. No-op when no episode is
-  // active, so normal initial connections emit nothing. Deliberately not sent
-  // on user shutdown mid-episode (a hang-up is not a restart outcome).
-  // ponytail: episode-level only — add per-attempt metrics if debugging ever
-  // needs that granularity.
+  // One metric per restart episode, sent at episode end. No-op when no
+  // episode is active; deliberately silent on user shutdown mid-episode.
   private sendIceRestartMetric(outcome: 'recovered' | 'exhausted' | 'aborted') {
     if (this.iceRestartEpisodeStartMs === null) {
       return;
@@ -1023,7 +1018,6 @@ export class StreamingClient {
     }
 
     if (this.iceRestartAttempts === 0) {
-      // New restart episode: stamp start + trigger for the episode metric.
       this.iceRestartEpisodeStartMs = performance.now();
       this.iceRestartEpisodeTrigger = this.peerConnection.iceConnectionState;
     }
@@ -1050,12 +1044,8 @@ export class StreamingClient {
       const currentIceState = this.peerConnection.iceConnectionState;
       if (currentIceState === 'connected' || currentIceState === 'completed') {
         this.iceRestartInProgress = false;
-        // The connected handler normally already closed the episode; this is a
-        // no-op then. It only fires if this branch wins the race against the
-        // iceconnectionstatechange dispatch.
+        // No-ops if the connected handler already closed the episode.
         this.sendIceRestartMetric('recovered');
-        // If ICE reconnected before reconnectForIceRestart() set the flag, the
-        // connected handler couldn't have cleared it — end the episode here too.
         this.signallingClient.endIceRestartReconnect();
         return;
       }
@@ -1122,9 +1112,6 @@ export class StreamingClient {
     if (!this.connectionReceivedAnswer && !this.iceRestartAwaitedAnswer) {
       // Offer still unanswered: give the in-flight answer one more cycle before
       // rolling it back and re-offering.
-      // ponytail: single grace cycle. An answer lost then arriving >2 cycles
-      // late could still glare with the next offer, but that self-heals via
-      // ICE-fail -> retry. Add generation tagging only if it shows up for real.
       this.iceRestartAwaitedAnswer = true;
       this.iceRestartInProgress = true;
       this.iceRestartWatchdogTimer = setTimeout(

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -58,6 +58,7 @@ export class StreamingClient {
   private connectionEstablishedEmitted = false;
   private iceRestartInProgress = false;
   private iceRestartAttempts = 0;
+  private iceRestartAwaitedAnswer = false;
   private iceRestartStopped = false; // set on shutdown; halts all restart activity
   private iceDisconnectedGraceTimer: ReturnType<typeof setTimeout> | null =
     null;
@@ -616,7 +617,20 @@ export class StreamingClient {
       case SignalMessageAction.ANSWER: {
         this.connectionMilestones?.record('answer_received');
         const answer = signalMessage.payload as RTCSessionDescriptionInit;
-        await this.peerConnection.setRemoteDescription(answer);
+        if (this.peerConnection.signalingState !== 'have-local-offer') {
+          // Late answer to a superseded / rolled-back restart offer — ignore it so
+          // it cannot be applied in a stable state or against a different offer.
+          break;
+        }
+        try {
+          await this.peerConnection.setRemoteDescription(answer);
+        } catch (err) {
+          console.error(
+            'StreamingClient - setRemoteDescription(answer) failed',
+            err,
+          );
+          break; // let the ICE restart watchdog retry
+        }
         this.connectionMilestones?.record('remote_description_set');
         this.connectionReceivedAnswer = true;
         // flush the remote buffer
@@ -792,10 +806,6 @@ export class StreamingClient {
         break;
       case 'failed':
         this.clearIceDisconnectedGraceTimer();
-        this.connectionMilestones?.publishFailure({
-          failureStage: 'ice_connection',
-          iceConnectionState: state,
-        });
         void this.restartIce();
         break;
     }
@@ -922,6 +932,10 @@ export class StreamingClient {
     }
     if (this.iceRestartAttempts >= MAX_ICE_RESTART_ATTEMPTS) {
       console.error('StreamingClient - restartIce: exhausted attempts');
+      this.connectionMilestones?.publishFailure({
+        failureStage: 'ice_connection',
+        iceConnectionState: this.peerConnection?.iceConnectionState,
+      });
       this.cancelIceRestart();
       this.handleWebrtcFailure(
         'The connection to our servers was lost. Please try again.',
@@ -975,17 +989,12 @@ export class StreamingClient {
       );
       this.flushIceRestartCandidateBuffer();
 
+      this.iceRestartAwaitedAnswer = false;
       this.clearIceRestartWatchdog();
-      this.iceRestartWatchdogTimer = setTimeout(() => {
-        this.iceRestartWatchdogTimer = null;
-        this.iceRestartInProgress = false;
-        if (this.iceRestartStopped) return;
-        const state = this.peerConnection?.iceConnectionState;
-        if (state === 'connected' || state === 'completed') {
-          return;
-        }
-        void this.restartIce();
-      }, ICE_RESTART_WATCHDOG_MS);
+      this.iceRestartWatchdogTimer = setTimeout(
+        () => this.onIceRestartWatchdog(),
+        ICE_RESTART_WATCHDOG_MS,
+      );
     } catch (err) {
       // The offer never made it out; drop candidates buffered for it (a retry
       // mints a fresh offer and gathers again).
@@ -1007,6 +1016,33 @@ export class StreamingClient {
     }
   }
 
+  // Watchdog for an outstanding restart offer. Only rolls back and re-offers
+  // once the current offer is resolved, so a second offer is never minted while
+  // the first offer's answer is still in flight (the ANSWER handler could
+  // otherwise apply it against the wrong offer).
+  private onIceRestartWatchdog() {
+    this.iceRestartWatchdogTimer = null;
+    this.iceRestartInProgress = false;
+    if (this.iceRestartStopped) return;
+    const state = this.peerConnection?.iceConnectionState;
+    if (state === 'connected' || state === 'completed') return;
+    if (!this.connectionReceivedAnswer && !this.iceRestartAwaitedAnswer) {
+      // Offer still unanswered: give the in-flight answer one more cycle before
+      // rolling it back and re-offering.
+      // ponytail: single grace cycle. An answer lost then arriving >2 cycles
+      // late could still glare with the next offer, but that self-heals via
+      // ICE-fail -> retry. Add generation tagging only if it shows up for real.
+      this.iceRestartAwaitedAnswer = true;
+      this.iceRestartInProgress = true;
+      this.iceRestartWatchdogTimer = setTimeout(
+        () => this.onIceRestartWatchdog(),
+        ICE_RESTART_WATCHDOG_MS,
+      );
+      return;
+    }
+    void this.restartIce();
+  }
+
   private onConnectionStateChange() {
     const connectionState = this.peerConnection?.connectionState;
     if (connectionState) {
@@ -1014,11 +1050,22 @@ export class StreamingClient {
         connectionState,
       });
     }
-    if (this.peerConnection?.connectionState === 'failed') {
-      this.connectionMilestones?.publishFailure({
-        failureStage: 'webrtc_connection',
-        connectionState: this.peerConnection.connectionState,
-      });
+    if (connectionState === 'failed') {
+      const iceState = this.peerConnection?.iceConnectionState;
+      const recovering =
+        !this.iceRestartStopped &&
+        (iceState === 'disconnected' || iceState === 'failed');
+      // A recoverable ICE failure also flips the aggregate state to 'failed'.
+      // The recorder is first-call-wins, so don't finalize failure telemetry
+      // while the ICE restart is still recovering; the terminal publish comes
+      // from restartIce (exhausted) or the 'closed' branch below. A genuine
+      // non-ICE failure (e.g. DTLS with ICE still connected) still publishes.
+      if (!recovering) {
+        this.connectionMilestones?.publishFailure({
+          failureStage: 'webrtc_connection',
+          connectionState,
+        });
+      }
     }
     if (this.peerConnection?.connectionState === 'closed') {
       console.error(

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -67,6 +67,12 @@ export class StreamingClient {
   private pendingWsOpenReject: ((reason?: unknown) => void) | null = null;
   private connectionReceivedAnswer = false;
   private remoteIceCandidateBuffer: RTCIceCandidate[] = [];
+
+  // While a re-offer is being minted and sent, local candidates are buffered here
+  // so they reach the server AFTER the restart offer (which carries the new ICE
+  // credentials); otherwise the engine adds them against the old generation and
+  // drops them. null = not buffering (normal path).
+  private iceRestartCandidateBuffer: RTCIceCandidate[] | null = null;
   private inputAudioStream: MediaStream | null = null;
   private dataChannel: RTCDataChannel | null = null;
   private videoElement: HTMLVideoElement | null = null;
@@ -744,6 +750,11 @@ export class StreamingClient {
           getIceCandidateMilestoneTags(event.candidate),
         );
       }
+      if (this.iceRestartCandidateBuffer) {
+        // Hold until the re-offer is sent (see restartIce).
+        this.iceRestartCandidateBuffer.push(event.candidate);
+        return;
+      }
       this.signallingClient.sendIceCandidate(event.candidate);
     } else {
       this.connectionMilestones?.record('ice_gathering_complete');
@@ -827,7 +838,19 @@ export class StreamingClient {
     const reject = this.pendingWsOpenReject;
     this.clearPendingWsOpenWait();
     if (reject) reject(new Error('ice restart cancelled'));
+    this.iceRestartCandidateBuffer = null;
     this.iceRestartInProgress = false;
+  }
+
+  // Send any candidates buffered while the re-offer was minted+sent, then stop
+  // buffering (see restartIce/onIceCandidate).
+  private flushIceRestartCandidateBuffer() {
+    const buffered = this.iceRestartCandidateBuffer;
+    this.iceRestartCandidateBuffer = null;
+    if (!buffered) return;
+    for (const candidate of buffered) {
+      this.signallingClient.sendIceCandidate(candidate);
+    }
   }
 
   private scheduleIceRestartAfterGrace() {
@@ -936,6 +959,13 @@ export class StreamingClient {
       this.remoteIceCandidateBuffer = [];
 
       const offer = await this.peerConnection.createOffer({ iceRestart: true });
+      // Buffer local candidates that gather from setLocalDescription until the
+      // re-offer is sent. The engine queues remote candidates only while it has
+      // no remote description; during a restart it still holds the OLD ICE
+      // credentials, so a candidate arriving before the re-offer is applied would
+      // be added against the old generation and dropped. WS messages are handled
+      // in order, so sending the offer first pins the new credentials server-side.
+      this.iceRestartCandidateBuffer = [];
       await this.peerConnection.setLocalDescription(offer);
       if (!this.peerConnection.localDescription) {
         throw new Error('null local description after ICE restart offer');
@@ -943,6 +973,7 @@ export class StreamingClient {
       await this.signallingClient.sendOffer(
         this.peerConnection.localDescription,
       );
+      this.flushIceRestartCandidateBuffer();
 
       this.clearIceRestartWatchdog();
       this.iceRestartWatchdogTimer = setTimeout(() => {
@@ -956,6 +987,9 @@ export class StreamingClient {
         void this.restartIce();
       }, ICE_RESTART_WATCHDOG_MS);
     } catch (err) {
+      // The offer never made it out; drop candidates buffered for it (a retry
+      // mints a fresh offer and gathers again).
+      this.iceRestartCandidateBuffer = null;
       console.error('StreamingClient - restartIce: error', err);
       this.iceRestartInProgress = false;
       if (

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -633,6 +633,7 @@ export class StreamingClient {
         }
         this.connectionMilestones?.record('remote_description_set');
         this.connectionReceivedAnswer = true;
+        this.onAnswerAccepted();
         // flush the remote buffer
         await this.flushRemoteIceCandidateBuffer();
         break;
@@ -822,6 +823,26 @@ export class StreamingClient {
     if (this.iceRestartWatchdogTimer) {
       clearTimeout(this.iceRestartWatchdogTimer);
       this.iceRestartWatchdogTimer = null;
+    }
+  }
+
+  private onAnswerAccepted() {
+    const wasAwaitingRestartAnswer =
+      this.iceRestartInProgress ||
+      this.iceRestartAwaitedAnswer ||
+      this.iceRestartWatchdogTimer !== null;
+
+    this.clearIceRestartWatchdog();
+    this.iceRestartAwaitedAnswer = false;
+
+    if (!wasAwaitingRestartAnswer) {
+      return;
+    }
+
+    this.iceRestartInProgress = false;
+    const state = this.peerConnection?.iceConnectionState;
+    if (state === 'disconnected' || state === 'failed') {
+      this.scheduleIceRestartAfterGrace();
     }
   }
 

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -59,6 +59,9 @@ export class StreamingClient {
   private iceRestartInProgress = false;
   private iceRestartAttempts = 0;
   private iceRestartAwaitedAnswer = false;
+  // Restart-episode telemetry (see sendIceRestartMetric). null = no episode.
+  private iceRestartEpisodeStartMs: number | null = null;
+  private iceRestartEpisodeTrigger: string | null = null;
   private iceRestartStopped = false; // set on shutdown; halts all restart activity
   private iceDisconnectedGraceTimer: ReturnType<typeof setTimeout> | null =
     null;
@@ -668,6 +671,9 @@ export class StreamingClient {
       }
       case SignalMessageAction.END_SESSION:
         const reason = signalMessage.payload as string;
+        // Server ended the session mid-restart: count the episode as aborted
+        // (unlike a user hang-up, which deliberately emits nothing).
+        this.sendIceRestartMetric('aborted');
         this.connectionMilestones?.publishFailure({
           failureStage: 'server_closed_connection',
         });
@@ -800,6 +806,7 @@ export class StreamingClient {
         this.clearIceDisconnectedGraceTimer();
         this.clearIceRestartWatchdog();
         this.iceRestartInProgress = false;
+        this.sendIceRestartMetric('recovered'); // before the attempts reset below
         this.iceRestartAttempts = 0;
         this.signallingClient.endIceRestartReconnect();
         if (!this.connectionEstablishedMilestoneRecorded) {
@@ -836,6 +843,34 @@ export class StreamingClient {
       clearTimeout(this.iceRestartWatchdogTimer);
       this.iceRestartWatchdogTimer = null;
     }
+  }
+
+  // One metric per restart episode, sent at episode end; complements the
+  // engine's server-side ICE recovery metrics. No-op when no episode is
+  // active, so normal initial connections emit nothing. Deliberately not sent
+  // on user shutdown mid-episode (a hang-up is not a restart outcome).
+  // ponytail: episode-level only — add per-attempt metrics if debugging ever
+  // needs that granularity.
+  private sendIceRestartMetric(outcome: 'recovered' | 'exhausted' | 'aborted') {
+    if (this.iceRestartEpisodeStartMs === null) {
+      return;
+    }
+    const durationMs = Math.round(
+      performance.now() - this.iceRestartEpisodeStartMs,
+    );
+    const trigger = this.iceRestartEpisodeTrigger ?? 'unknown';
+    this.iceRestartEpisodeStartMs = null;
+    this.iceRestartEpisodeTrigger = null;
+    sendClientMetric(
+      ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_ICE_RESTART,
+      '1',
+      {
+        outcome,
+        attempts: this.iceRestartAttempts,
+        durationMs,
+        trigger,
+      },
+    );
   }
 
   // True while a restart offer is outstanding (in-progress gate, awaited-answer
@@ -969,6 +1004,7 @@ export class StreamingClient {
     }
     if (this.signallingClient.isPermanentlyClosed()) {
       // Session is already ending via the signalling layer; stop spinning.
+      this.sendIceRestartMetric('aborted');
       this.cancelIceRestart();
       return;
     }
@@ -978,6 +1014,7 @@ export class StreamingClient {
         failureStage: 'ice_connection',
         iceConnectionState: this.peerConnection?.iceConnectionState,
       });
+      this.sendIceRestartMetric('exhausted');
       this.cancelIceRestart();
       this.handleWebrtcFailure(
         'The connection to our servers was lost. Please try again.',
@@ -985,6 +1022,11 @@ export class StreamingClient {
       return;
     }
 
+    if (this.iceRestartAttempts === 0) {
+      // New restart episode: stamp start + trigger for the episode metric.
+      this.iceRestartEpisodeStartMs = performance.now();
+      this.iceRestartEpisodeTrigger = this.peerConnection.iceConnectionState;
+    }
     // Set the in-progress gate BEFORE any await so a concurrent trigger
     // (watchdog retry + ICE 'failed' event) cannot start a second restart.
     this.iceRestartInProgress = true;
@@ -1008,6 +1050,10 @@ export class StreamingClient {
       const currentIceState = this.peerConnection.iceConnectionState;
       if (currentIceState === 'connected' || currentIceState === 'completed') {
         this.iceRestartInProgress = false;
+        // The connected handler normally already closed the episode; this is a
+        // no-op then. It only fires if this branch wins the race against the
+        // iceconnectionstatechange dispatch.
+        this.sendIceRestartMetric('recovered');
         // If ICE reconnected before reconnectForIceRestart() set the flag, the
         // connected handler couldn't have cleared it — end the episode here too.
         this.signallingClient.endIceRestartReconnect();
@@ -1046,10 +1092,12 @@ export class StreamingClient {
       this.iceRestartCandidateBuffer = null;
       console.error('StreamingClient - restartIce: error', err);
       this.iceRestartInProgress = false;
-      if (
-        this.iceRestartStopped ||
-        this.signallingClient.isPermanentlyClosed()
-      ) {
+      if (this.iceRestartStopped) {
+        this.cancelIceRestart();
+        return;
+      }
+      if (this.signallingClient.isPermanentlyClosed()) {
+        this.sendIceRestartMetric('aborted');
         this.cancelIceRestart();
         return; // signalling layer already emitted CONNECTION_CLOSED
       }

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -921,6 +921,10 @@ export class StreamingClient {
     if (reject) reject(new Error('ice restart cancelled'));
     this.iceRestartCandidateBuffer = null;
     this.iceRestartInProgress = false;
+    // End the metric episode: a late END_SESSION after shutdown must not
+    // count the hang-up as an aborted restart.
+    this.iceRestartEpisodeStartMs = null;
+    this.iceRestartEpisodeTrigger = null;
     this.signallingClient.endIceRestartReconnect();
   }
 

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -856,13 +856,14 @@ export class StreamingClient {
     const trigger = this.iceRestartEpisodeTrigger ?? 'unknown';
     this.iceRestartEpisodeStartMs = null;
     this.iceRestartEpisodeTrigger = null;
+    // durationMs is the value, not a tag: near-unique tag values explode
+    // InfluxDB series cardinality. Episode count = count of points.
     sendClientMetric(
       ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_ICE_RESTART,
-      '1',
+      durationMs,
       {
         outcome,
         attempts: this.iceRestartAttempts,
-        durationMs,
         trigger,
       },
     );

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -629,7 +629,12 @@ export class StreamingClient {
             'StreamingClient - setRemoteDescription(answer) failed',
             err,
           );
-          break; // let the ICE restart watchdog retry
+          if (!this.isAwaitingRestartAnswer()) {
+            // Initial-connection answer: no restart watchdog will retry, so
+            // surface the failure instead of hanging the connection.
+            this.handleWebrtcFailure(err);
+          }
+          break; // restart answers: let the ICE restart watchdog retry
         }
         this.connectionMilestones?.record('remote_description_set');
         this.connectionReceivedAnswer = true;
@@ -790,6 +795,7 @@ export class StreamingClient {
         this.clearIceRestartWatchdog();
         this.iceRestartInProgress = false;
         this.iceRestartAttempts = 0;
+        this.signallingClient.endIceRestartReconnect();
         if (!this.connectionEstablishedMilestoneRecorded) {
           this.connectionEstablishedMilestoneRecorded = true;
           this.connectionMilestones?.record('client_connection_established', {
@@ -826,11 +832,19 @@ export class StreamingClient {
     }
   }
 
-  private onAnswerAccepted() {
-    const wasAwaitingRestartAnswer =
+  // True while a restart offer is outstanding (in-progress gate, awaited-answer
+  // grace cycle, or armed watchdog) — i.e. an incoming answer belongs to an ICE
+  // restart rather than the initial connection.
+  private isAwaitingRestartAnswer(): boolean {
+    return (
       this.iceRestartInProgress ||
       this.iceRestartAwaitedAnswer ||
-      this.iceRestartWatchdogTimer !== null;
+      this.iceRestartWatchdogTimer !== null
+    );
+  }
+
+  private onAnswerAccepted() {
+    const wasAwaitingRestartAnswer = this.isAwaitingRestartAnswer();
 
     this.clearIceRestartWatchdog();
     this.iceRestartAwaitedAnswer = false;
@@ -871,6 +885,7 @@ export class StreamingClient {
     if (reject) reject(new Error('ice restart cancelled'));
     this.iceRestartCandidateBuffer = null;
     this.iceRestartInProgress = false;
+    this.signallingClient.endIceRestartReconnect();
   }
 
   // Send any candidates buffered while the re-offer was minted+sent, then stop


### PR DESCRIPTION
## Summary
Recover an active session across a client **network change** (e.g. WiFi ↔ cellular) instead of tearing it down and forcing a full reconnect.

- On ICE `disconnected`, wait a short grace period then restart; on `failed`, restart immediately. Bounded retries via a watchdog; on exhaustion, fall back to the existing WebRTC-failure path.
- A restart mints a fresh offer with `iceRestart: true` over the existing `RTCPeerConnection`, preserving DTLS/SRTP and avatar state.
- On the first attempt of a restart episode, force a fresh signalling socket (`reconnectForIceRestart`). A network switch can leave the old WebSocket **half-open** (`readyState` stays OPEN, no `close` event), so an offer sent on it is silently dropped.
- Expose `SignallingClient` connection + terminal state; never send a restart offer on a dead socket (`ensureSignallingConnected`).

Existing connection-milestone recording is preserved. One deliberate behaviour change: `CONNECTION_ESTABLISHED` now fires **once per session** rather than on every ICE `connected` transition, so an ICE restart doesn't look like a brand-new connection to consumers.

Scope: `src/modules/SignallingClient.ts`, `src/modules/StreamingClient.ts`.

## Server dependency
Requires the corresponding server-side ICE-restart support in the engine (renegotiate a re-offer as an ICE restart + unblock the mid-session signalling-socket reconnect). Without it, the network-switch path won't complete.

## Test plan
- [x] `tsc --noEmit`, eslint, `npm run build` clean
- [x] End-to-end on dev: WiFi↔cellular switch → ICE + DTLS recover, audio/video resume, session stays alive
- [ ] Reviewer: confirm no double-emit of `CONNECTION_ESTABLISHED` and that milestone recording is unchanged for the normal (non-restart) path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add automatic ICE restart to recover active WebRTC sessions after client network changes without a full reconnect. Media resumes quickly and session/avatar state stays intact.

- **New Features**
  - On ICE `disconnected`, wait ~2s then restart; on `failed`, restart immediately. Bounded retries via a watchdog; roll back before re-offer, prevent double restarts, ignore late answers to superseded offers. On exhaustion, fall back to the existing failure path.
  - First attempt forces a fresh signaling WebSocket and waits for `WEB_SOCKET_OPEN`. A restart-specific reconnect budget stays active for the whole episode and ends on success, cancel, or self-recovery. Stale sockets are detached/closed (guarded by `isPermanentlyClosed()`), with close errors logged.
  - Reuse the same `RTCPeerConnection`. Buffer local ICE candidates until the restart offer is sent, then flush. Apply ANSWERs only in `have-local-offer`; fail fast only for initial answers. `CONNECTION_ESTABLISHED` now emits once per session; milestone recording is unchanged and failure telemetry is suppressed during recovery.
  - Emit `client_ice_restart` metric once per episode with outcome (`recovered`/`exhausted`/`aborted`), attempts, trigger, and durationMs (as the metric value). Silent on user shutdown; server `END_SESSION` mid-episode counts as `aborted`. Cancel now clears the metric episode to avoid miscounting a late `END_SESSION` after user shutdown.

- **Migration**
  - Requires server support for ICE restarts and mid-session signaling-socket reconnects.
  - If you relied on multiple `CONNECTION_ESTABLISHED` emits after reconnects, update listeners to handle a single emit per session.

<sup>Written for commit 0237106c6f66bf08f8010ac21bb6437f2552b45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

