### PR TITLE
ENG-2419 Add client timestamps to signal metrics

### DIFF
--- a/src/lib/ClientMetrics.ts
+++ b/src/lib/ClientMetrics.ts
@@ -59,6 +59,7 @@ export const setMetricsContext = (context: Partial<AnamMetricsContext>) => {
 export interface ClientMetricPayload {
   name: string;
   value: string | number;
+  clientTimestamp?: string;
   tags?: Record<string, string | number>;
 }
 
@@ -95,6 +96,7 @@ export const sendClientMetrics = async (metrics: ClientMetricPayload[]) => {
 
     const normalizedMetrics = metrics.map((metric) => ({
       ...metric,
+      clientTimestamp: metric.clientTimestamp ?? new Date().toISOString(),
       tags: buildMetricTags(metric.tags),
     }));
 

--- a/src/lib/ConnectionMilestones.ts
+++ b/src/lib/ConnectionMilestones.ts
@@ -19,6 +19,7 @@ type ConnectionMilestoneTags = Record<
 interface ClientConnectionMilestone {
   name: string;
   elapsedMs: number;
+  clientTimestamp: string;
   tags?: Record<string, ConnectionMilestoneTagValue>;
 }
 
@@ -78,6 +79,7 @@ export class ClientConnectionMilestoneRecorder {
     const milestone: ClientConnectionMilestone = {
       name,
       elapsedMs: this.elapsedMs(),
+      clientTimestamp: new Date().toISOString(),
     };
     if (Object.keys(sanitizedTags).length > 0) {
       milestone.tags = sanitizedTags;
@@ -166,6 +168,7 @@ export class ClientConnectionMilestoneRecorder {
       ...this.milestones.map((milestone, index) => ({
         name: ClientMetricMeasurement.CLIENT_METRIC_MEASUREMENT_CONNECTION_MILESTONE,
         value: milestone.elapsedMs,
+        clientTimestamp: milestone.clientTimestamp,
         tags: sanitizeMetricTags({
           ...this.context,
           publishReason: reason,

--- a/test/connectionMilestonesHarness.js
+++ b/test/connectionMilestonesHarness.js
@@ -31,6 +31,19 @@ const assertNoSerializedMilestoneTag = (request) => {
     );
   });
 };
+const assertClientTimestamps = (request) => {
+  getMetrics(request).forEach((metric) => {
+    assert.equal(
+      typeof metric.clientTimestamp,
+      'string',
+      `${metric.name} should include clientTimestamp`,
+    );
+    assert.ok(
+      !Number.isNaN(Date.parse(metric.clientTimestamp)),
+      `${metric.name} should include an ISO clientTimestamp`,
+    );
+  });
+};
 
 const createRecorder = ({
   sampleRatio = 0,
@@ -72,6 +85,7 @@ async function runHarness() {
   assert.equal(requests.length, 1, 'sampled success should publish once');
   assert.equal(getMetrics(requests[0]).length, 3);
   assertNoSerializedMilestoneTag(requests[0]);
+  assertClientTimestamps(requests[0]);
   const sampledSummary = getSummaryMetric(requests[0]);
   const sampledDetails = getDetailMetrics(requests[0]);
   assert.equal(sampledSummary.tags.publishReason, 'sampled');
@@ -102,6 +116,7 @@ async function runHarness() {
   recorder.recordSessionSuccess({ detectionMethod: 'harness' });
   assert.equal(requests.length, 1, 'slow success should publish once');
   assertNoSerializedMilestoneTag(requests[0]);
+  assertClientTimestamps(requests[0]);
   const slowSummary = getSummaryMetric(requests[0]);
   const slowDetails = getDetailMetrics(requests[0]);
   assert.equal(slowSummary.tags.publishReason, 'slow');
@@ -119,6 +134,7 @@ async function runHarness() {
   recorder.publishFailure({ failureStage: 'harness' });
   assert.equal(requests.length, 1, 'failed attempt should publish once');
   assertNoSerializedMilestoneTag(requests[0]);
+  assertClientTimestamps(requests[0]);
   const failureSummary = getSummaryMetric(requests[0]);
   const failureDetails = getDetailMetrics(requests[0]);
   assert.equal(failureSummary.tags.publishReason, 'failed');


### PR DESCRIPTION
## Summary

- Add a top-level `clientTimestamp` ISO string to every client metric payload.
- Preserve per-milestone client event time for `client_connection_milestone` entries by recording the timestamp when each milestone is captured, not when the batch is sent.
- Add harness coverage for client timestamps in milestone metric payloads.

Linear: https://linear.app/anam-ai/issue/ENG-2419/add-client-side-timestamps-to-client-signal-payloads

## Payload Examples

Before:

```json
{
  "name": "client_session_success",
  "value": "1",
  "tags": {
    "sdk": "4.18.0",
    "sessionId": "de068031-4b48-4ea3-90cf-2d9f67c5df69",
    "attemptCorrelationId": "b9ecf937-b94e-442b-9456-c8bae0f815d6",
    "outcome": "videoElement"
  }
}
```

After:

```json
{
  "name": "client_session_success",
  "value": "1",
  "clientTimestamp": "2026-07-07T11:10:47.860Z",
  "tags": {
    "sdk": "4.18.0",
    "sessionId": "de068031-4b48-4ea3-90cf-2d9f67c5df69",
    "attemptCorrelationId": "b9ecf937-b94e-442b-9456-c8bae0f815d6",
    "outcome": "videoElement"
  }
}
```

Batched milestone detail after:

```json
{
  "metrics": [
    {
      "name": "client_connection_milestones",
      "value": "1",
      "clientTimestamp": "2026-07-07T11:10:47.900Z",
      "tags": {
        "publishReason": "sampled",
        "milestoneCount": 2
      }
    },
    {
      "name": "client_connection_milestone",
      "value": 0,
      "clientTimestamp": "2026-07-07T11:10:46.131Z",
      "tags": {
        "milestone": "client_session_attempt",
        "sequence": 0
      }
    },
    {
      "name": "client_connection_milestone",
      "value": 1729,
      "clientTimestamp": "2026-07-07T11:10:47.860Z",
      "tags": {
        "milestone": "client_session_success",
        "sequence": 1
      }
    }
  ]
}
```

## API Follow-up

`ENG-2419` tracks the API side: accept `clientTimestamp` on single and batched metric payloads, persist it separately from ingestion time, and expose both timestamps in `anamctl session signals`.

## Test

```bash
npm run test:connection-milestones
```
