### PR TITLE
feat: adding contentIndex and correlationId to WebRtcTextMessageEvent

### DIFF
--- a/src/modules/MessageHistoryClient.ts
+++ b/src/modules/MessageHistoryClient.ts
@@ -29,12 +29,16 @@ export class MessageHistoryClient {
   private webRtcTextMessageEventToMessageStreamEvent(
     event: WebRtcTextMessageEvent,
   ): MessageStreamEvent {
+    const correlationId =
+      event.user_action_correlation_id ?? event.correlationId;
     return {
       id: `${event.role}::${event.message_id}`, // id is the same for persona and user for a single question response, so we need to differentiate them
       content: event.content,
       role: event.role as MessageRole,
       endOfSpeech: event.end_of_speech,
       interrupted: event.interrupted,
+      contentIndex: event.content_index,
+      ...(correlationId ? { correlationId } : {}),
       ...(event.cue_tag ? { cueTag: event.cue_tag } : {}),
     };
   }

--- a/src/types/messageHistory/MessageStreamEvent.ts
+++ b/src/types/messageHistory/MessageStreamEvent.ts
@@ -6,6 +6,10 @@ export interface MessageStreamEvent {
   role: MessageRole;
   endOfSpeech: boolean;
   interrupted: boolean;
+  // Zero-based index of this chunk within the turn.
+  contentIndex: number;
+  // Turn correlation id, matching the id used when driving talk streams.
+  correlationId?: string;
   // Director-note cue applied to this event's content. Undefined when no cue applies.
   cueTag?: string;
 }

--- a/src/types/messageHistory/MessageStreamEvent.ts
+++ b/src/types/messageHistory/MessageStreamEvent.ts
@@ -6,7 +6,7 @@ export interface MessageStreamEvent {
   role: MessageRole;
   endOfSpeech: boolean;
   interrupted: boolean;
-  // Zero-based index of this chunk within the turn.
+  // Zero-based index of this chunk within the turn. Optional here for backwards compatibility.
   contentIndex?: number;
   // Turn correlation id, matching the id used when driving talk streams.
   correlationId?: string;

--- a/src/types/messageHistory/MessageStreamEvent.ts
+++ b/src/types/messageHistory/MessageStreamEvent.ts
@@ -7,7 +7,7 @@ export interface MessageStreamEvent {
   endOfSpeech: boolean;
   interrupted: boolean;
   // Zero-based index of this chunk within the turn.
-  contentIndex: number;
+  contentIndex?: number;
   // Turn correlation id, matching the id used when driving talk streams.
   correlationId?: string;
   // Director-note cue applied to this event's content. Undefined when no cue applies.

--- a/src/types/streaming/WebRtcTextMessageEvent.ts
+++ b/src/types/streaming/WebRtcTextMessageEvent.ts
@@ -6,10 +6,9 @@ export interface WebRtcTextMessageEvent {
   end_of_speech: boolean;
   interrupted: boolean;
   // Director-note cue applied to this chunk's content. Empty or absent when no cue applies;
-  // only sent by engines with director-note cues enabled.
   cue_tag?: string;
-  // Turn correlation id. Engines emit it as `user_action_correlation_id`; some payloads use the
-  // `correlationId` alias. Absent on older engines.
+  // Turn correlation id. Emitted as `user_action_correlation_id`
   user_action_correlation_id?: string;
+  // Alias for `user_action_correlation_id`
   correlationId?: string;
 }

--- a/src/types/streaming/WebRtcTextMessageEvent.ts
+++ b/src/types/streaming/WebRtcTextMessageEvent.ts
@@ -8,4 +8,8 @@ export interface WebRtcTextMessageEvent {
   // Director-note cue applied to this chunk's content. Empty or absent when no cue applies;
   // only sent by engines with director-note cues enabled.
   cue_tag?: string;
+  // Turn correlation id. Engines emit it as `user_action_correlation_id`; some payloads use the
+  // `correlationId` alias. Absent on older engines.
+  user_action_correlation_id?: string;
+  correlationId?: string;
 }


### PR DESCRIPTION
WebRTCTextMessageEvents currently don't expose the correlation ID or contentIndex. Adding these makes it easier to track different responses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose content indexing and turn correlation on streaming text events so clients can order chunks and link turns across WebRTC/talk streams. Adds fields on `WebRtcTextMessageEvent` and forwards them into `MessageStreamEvent`.

- **New Features**
  - `MessageStreamEvent`: adds optional `contentIndex` (zero-based) and optional `correlationId`.
  - `WebRtcTextMessageEvent`: adds `user_action_correlation_id` (alias: `correlationId`). `MessageHistoryClient` maps correlation from either field and forwards `content_index` to `contentIndex`. Cue tag comments clarified.

- **Migration**
  - If you construct `MessageStreamEvent` yourself, you can include `contentIndex` (optional).
  - No changes needed if you don’t use `correlationId` (it’s optional).

<sup>Written for commit 30c10b9498997380ba79d53d634a1ee32b376011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

