### PR TITLE
Add AI avatar disclosure session option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ import { createClient } from '@anam-ai/js-sdk';
 const anamClient = createClient('your-session-token');
 ```
 
+To request the AI avatar disclosure at session start:
+
+```typescript
+const anamClient = createClient('your-session-token', {
+  showAiAvatarDisclosure: true,
+});
+```
+
 Regardless of whether you initialise the client using an API key or session token the client exposes the same set of available methods for streaming.
 
 [See here](#starting-a-session-in-production-environments) for an example sequence diagram of starting a session in production environments.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import { createClient } from '@anam-ai/js-sdk';
 const anamClient = createClient('your-session-token');
 ```
 
-To request the AI avatar disclosure at session start:
+To show the AI avatar disclosure throughout the session:
 
 ```typescript
 const anamClient = createClient('your-session-token', {

--- a/README.md
+++ b/README.md
@@ -107,14 +107,6 @@ import { createClient } from '@anam-ai/js-sdk';
 const anamClient = createClient('your-session-token');
 ```
 
-To show the AI avatar disclosure throughout the session:
-
-```typescript
-const anamClient = createClient('your-session-token', {
-  showAiAvatarDisclosure: true,
-});
-```
-
 Regardless of whether you initialise the client using an API key or session token the client exposes the same set of available methods for streaming.
 
 [See here](#starting-a-session-in-production-environments) for an example sequence diagram of starting a session in production environments.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ import { createClient } from '@anam-ai/js-sdk';
 const anamClient = createClient('your-session-token');
 ```
 
+To show the AI avatar disclosure throughout the session:
+
+```typescript
+const anamClient = createClient('your-session-token', {
+  showAIAvatarDisclosure: true,
+});
+```
+
 Regardless of whether you initialise the client using an API key or session token the client exposes the same set of available methods for streaming.
 
 [See here](#starting-a-session-in-production-environments) for an example sequence diagram of starting a session in production environments.

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -211,6 +211,10 @@ export default class AnamClient {
     if (this.clientOptions?.voiceDetection) {
       sessionOptions.voiceDetection = this.clientOptions.voiceDetection;
     }
+    if (this.clientOptions?.showAiAvatarDisclosure !== undefined) {
+      sessionOptions.showAiAvatarDisclosure =
+        this.clientOptions.showAiAvatarDisclosure;
+    }
     // return undefined if no options are set
     if (Object.keys(sessionOptions).length === 0) {
       return undefined;

--- a/src/AnamClient.ts
+++ b/src/AnamClient.ts
@@ -211,9 +211,9 @@ export default class AnamClient {
     if (this.clientOptions?.voiceDetection) {
       sessionOptions.voiceDetection = this.clientOptions.voiceDetection;
     }
-    if (this.clientOptions?.showAiAvatarDisclosure !== undefined) {
-      sessionOptions.showAiAvatarDisclosure =
-        this.clientOptions.showAiAvatarDisclosure;
+    if (this.clientOptions?.showAIAvatarDisclosure !== undefined) {
+      sessionOptions.showAIAvatarDisclosure =
+        this.clientOptions.showAIAvatarDisclosure;
     }
     // return undefined if no options are set
     if (Object.keys(sessionOptions).length === 0) {

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -5,6 +5,11 @@ import { VoiceDetectionOptions } from './VoiceDetectionOptions';
 export interface AnamPublicClientOptions {
   api?: ApiOptions;
   voiceDetection?: VoiceDetectionOptions;
+  /**
+   * Show the AI avatar disclosure at session start.
+   * Omit to use Anam's default. Explicit false requires an eligible plan.
+   */
+  showAiAvatarDisclosure?: boolean;
   audioDeviceId?: string;
   disableInputAudio?: boolean;
   metrics?: ConnectionMilestoneMetricsOptions & {

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -6,7 +6,7 @@ export interface AnamPublicClientOptions {
   api?: ApiOptions;
   voiceDetection?: VoiceDetectionOptions;
   /**
-   * Show the AI avatar disclosure at session start.
+   * Show the AI avatar disclosure throughout the session.
    * Omit to use Anam's default. Explicit false requires an eligible plan.
    */
   showAiAvatarDisclosure?: boolean;

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -5,11 +5,7 @@ import { VoiceDetectionOptions } from './VoiceDetectionOptions';
 export interface AnamPublicClientOptions {
   api?: ApiOptions;
   voiceDetection?: VoiceDetectionOptions;
-  /**
-   * Show the AI avatar disclosure throughout the session.
-   * Omit to use Anam's default. Explicit false requires an eligible plan.
-   */
-  showAiAvatarDisclosure?: boolean;
+  showAIAvatarDisclosure?: boolean;
   audioDeviceId?: string;
   disableInputAudio?: boolean;
   metrics?: ConnectionMilestoneMetricsOptions & {

--- a/src/types/AnamPublicClientOptions.ts
+++ b/src/types/AnamPublicClientOptions.ts
@@ -5,6 +5,10 @@ import { VoiceDetectionOptions } from './VoiceDetectionOptions';
 export interface AnamPublicClientOptions {
   api?: ApiOptions;
   voiceDetection?: VoiceDetectionOptions;
+  /**
+   * Show the AI avatar disclosure throughout the session.
+   * Omit to use Anam's default.
+   */
   showAIAvatarDisclosure?: boolean;
   audioDeviceId?: string;
   disableInputAudio?: boolean;

--- a/src/types/coreApi/StartSessionOptions.ts
+++ b/src/types/coreApi/StartSessionOptions.ts
@@ -2,4 +2,5 @@ import { VoiceDetectionOptions } from '../VoiceDetectionOptions';
 
 export interface StartSessionOptions {
   voiceDetection?: VoiceDetectionOptions;
+  showAiAvatarDisclosure?: boolean;
 }

--- a/src/types/coreApi/StartSessionOptions.ts
+++ b/src/types/coreApi/StartSessionOptions.ts
@@ -2,5 +2,5 @@ import { VoiceDetectionOptions } from '../VoiceDetectionOptions';
 
 export interface StartSessionOptions {
   voiceDetection?: VoiceDetectionOptions;
-  showAiAvatarDisclosure?: boolean;
+  showAIAvatarDisclosure?: boolean;
 }


### PR DESCRIPTION
## Summary
- expose `showAiAvatarDisclosure` on public client options
- forward the value through the existing start-session options payload
- document that the enabled disclosure remains visible throughout the session

## Test plan
- `npm run build`
- targeted ESLint
- `npm test`

## Related
- Lab policy/API: https://github.com/anam-org/anam-lab/pull/1874
- Engine: https://github.com/anam-org/anam-engine/pull/3176