### PR TITLE
fix: mirror release version into src so publish-time rebuild keeps it

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
     [
       "semantic-release-mirror-version",
       {
-        "fileGlob": "./dist/**/*.js",
+        "fileGlob": "./{src,dist}/**/*.{ts,js}",
         "placeholderRegExp": "0\\.0\\.0-automated"
       }
     ],

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,9 @@ export const DEFAULT_API_VERSION = '/v1'; // include the leading slash
 
 export const CLIENT_METADATA = {
   client: 'js-sdk',
+  // Placeholder substituted by semantic-release-mirror-version. The substitution
+  // must happen here in src, not only in dist: `npm publish` re-runs the `prepare`
+  // build, which would otherwise regenerate dist with the placeholder intact.
   version: '0.0.0-automated',
 };
 


### PR DESCRIPTION
## Problem

Every npm release since **v4.20.1** ships with `CLIENT_METADATA.version` set to the placeholder `0.0.0-automated` instead of the real version, while `package.json` carries the correct version. This breaks client metrics that rely on the SDK reporting its version.

**Affected published versions: 4.20.1, 4.21.0, 4.22.0, 4.23.0** (verified by unpacking the npm tarballs; 4.20.0 is the last good release).

## Root cause

3808c46 ("Build SDK for Git dependency installs", Jul 16) changed the `prepare` script from `husky` to `npm run build`. `npm publish` runs the `prepare` lifecycle script when packing, so the release flow became:

1. Workflow builds `dist` (contains the placeholder).
2. `semantic-release-mirror-version` substitutes the real version into `dist/**/*.js`. ✅
3. `@semantic-release/npm` writes the real version into `package.json` and runs `npm publish`.
4. `npm publish` triggers `prepare` → `npm run build` → `rimraf dist` + rebuild from the unmodified source → the placeholder is back in `dist`. ❌
5. The freshly rebuilt (placeholder) `dist` is what gets packed and published. `package.json` survives because the build doesn't touch it.

## Fix

Widen the mirror plugin's `fileGlob` to `./{src,dist}/**/*.{ts,js}` so the version is substituted into `src/lib/constants.ts` as well. The publish-time rebuild then compiles the already-substituted source, so the published `dist` keeps the real version regardless of how many times it is rebuilt.

Verified locally by simulating the full release sequence: build → run the mirror plugin with a test version → `npm pack` (triggers the same `prepare` rebuild as publish) → unpacked tarball contains the test version in `dist/main/lib/constants.js`.

## Notes

- The next release cut from main will be the first with a correct constants version; consider whether the four affected versions warrant a patch release or npm deprecation notice.
- 3808c46 also dropped `husky` from `prepare`, so git hooks (commitlint/pretty-quick) no longer install locally — not addressed here, flagging in case it was unintentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes published packages reporting `CLIENT_METADATA.version` as `0.0.0-automated` by mirroring the release version into `src` so the publish-time rebuild preserves it. Future releases now ship the correct SDK version in `dist`.

- **Bug Fixes**
  - Expanded `semantic-release-mirror-version` `fileGlob` to `./{src,dist}/**/*.{ts,js}` so `src/lib/constants.ts` is substituted before the `prepare` rebuild.
  - Verified via `npm pack`: the rebuilt `dist` keeps the real version.

<sup>Written for commit e5bc037061ba98397a9872e61567e5c5bd6a44c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/anam-org/javascript-sdk/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

