### PR TITLE
feat: pre-gather ICE candidates

### DIFF
--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -506,7 +506,10 @@ export class StreamingClient {
           'StreamingClient - startConnection: error preparing peer connection',
           error,
         );
-        this.handleWebrtcFailure(error);
+        // If the connection was torn down while the pre-gather task was still
+        // in flight, shutdown() has already set iceRestartStopped and the
+        // rejection is expected - don't surface a spurious WebRTC failure.
+        if (!this.iceRestartStopped) this.handleWebrtcFailure(error);
       });
       // Establish the signalling channel concurrently with ICE gathering.
       this.signallingClient.connect();

--- a/src/modules/StreamingClient.ts
+++ b/src/modules/StreamingClient.ts
@@ -495,7 +495,20 @@ export class StreamingClient {
       }
       this.resetAttemptScopedMilestoneState();
       this.connectionMilestones?.record('connection_start_requested');
-      // start the connection
+      // Pre-gather ICE candidates in parallel with the WebSocket handshake.
+      // Creating the peer connection and local offer now starts ICE gathering
+      // (including any TURN allocation) immediately, instead of waiting for the
+      // socket to open. The offer and trickled candidates are queued by the
+      // SignallingClient's sending buffer and flushed, in order, once the
+      // socket opens - so the connection can proceed as soon as signalling is up.
+      void this.initPeerConnectionAndSendOffer().catch((error) => {
+        console.error(
+          'StreamingClient - startConnection: error preparing peer connection',
+          error,
+        );
+        this.handleWebrtcFailure(error);
+      });
+      // Establish the signalling channel concurrently with ICE gathering.
       this.signallingClient.connect();
     } catch (error) {
       console.error('StreamingClient - startConnection: error', error);


### PR DESCRIPTION
We wait to gather ICE candidates until the websocket is established. But for TURN connections, the gathering of ICE candidates is relatively slow. pre-gathering the ICE candidates means we can overlap the wss connection time with the ice gathering and reduce the latency of the slowest path.

The impact for non-TURN connections is negligible. 